### PR TITLE
Adding an extra parameter for Csv output

### DIFF
--- a/klass-api/src/main/asciidoc/api-guide.adoc
+++ b/klass-api/src/main/asciidoc/api-guide.adoc
@@ -517,6 +517,19 @@ include::{snippets}/csv-separator-example/curl-request.adoc[]
 ===== Example response
 include::{snippets}/csv-separator-example/http-response.adoc[]
 
+
+
+=== csvFields
+`csvFields` is an optional parameter that allows you to specify which columns and in what order you want them to appear
+in the Csv output. Please note that the column names are case sensitive and adding an non-existing column may result
+in an invalid Csv.
+
+===== Example request for csvSeparator=;
+include::{snippets}/csv-fields-example/curl-request.adoc[]
+===== Example response
+include::{snippets}/csv-fields-example/http-response.adoc[]
+
+
 === language
 `language` is used to specify which language data shall be presented in. Default if none is selected is nb (Norwegian Bokmål).
 

--- a/klass-api/src/main/asciidoc/api-guide.adoc
+++ b/klass-api/src/main/asciidoc/api-guide.adoc
@@ -521,8 +521,10 @@ include::{snippets}/csv-separator-example/http-response.adoc[]
 
 === csvFields
 `csvFields` is an optional parameter that allows you to specify which columns and in what order you want them to appear
-in the Csv output. Please note that the column names are case sensitive and adding an non-existing column may result
-in an invalid Csv.
+in the Csv output.
+
+Please note that the field names are case sensitive If the service fails to match  a field name  with the available data
+a 400 BAD REQUEST response will be returned.
 
 ===== Example request for csvSeparator=;
 include::{snippets}/csv-fields-example/curl-request.adoc[]

--- a/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
@@ -14,6 +14,7 @@ import javax.transaction.Transactional;
 
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import no.ssb.klass.api.controllers.validators.CsvFieldsValidator;
 import no.ssb.klass.api.dto.CodeChangeItem;
 import no.ssb.klass.api.dto.CodeItem;
 import no.ssb.klass.api.dto.CorrespondenceItem;
@@ -96,15 +97,18 @@ public class ClassificationController {
     private final SubscriberService subscriberService;
     private final SearchService searchService;
     private final StatisticsService statisticsService;
+    private final CsvFieldsValidator csvFieldsValidator;
 
     @Autowired
     public ClassificationController(ClassificationService classificationService,
             SubscriberService subscriberService,
-            SearchService searchService, StatisticsService statisticsService) {
+            SearchService searchService, StatisticsService statisticsService,
+            CsvFieldsValidator csvFieldsValidator) {
         this.classificationService = classificationService;
         this.subscriberService = subscriberService;
         this.searchService = searchService;
         this.statisticsService = statisticsService;
+        this.csvFieldsValidator = csvFieldsValidator;
     }
 
     @ExceptionHandler
@@ -283,7 +287,7 @@ public class ClassificationController {
 
         if (!csvFields.isEmpty())  {
             List<String> csvFieldsList = getCsvFieldsList(csvFields);
-            validateFieldsList(CodeChangeItem.class, csvFieldsList);
+            csvFieldsValidator.validateFieldsChangeItemSchema( csvFieldsList);
             codeList.setCsvFields(csvFieldsList);
         }
         return codeList;
@@ -308,7 +312,7 @@ public class ClassificationController {
 
         if (!csvFields.isEmpty())  {
             List<String> csvFieldsList = getCsvFieldsList(csvFields);
-            validateFieldsList(CodeItem.class, csvFieldsList);
+            csvFieldsValidator.validateFieldsCodeItem(csvFieldsList);
             codeList.setCsvFields(csvFieldsList);
         }
         return codeList;
@@ -348,7 +352,7 @@ public class ClassificationController {
 
         if (!csvFields.isEmpty())  {
             List<String> csvFieldsList = getCsvFieldsList(csvFields);
-            validateFieldsList(CodeItem.class, csvFieldsList);
+            csvFieldsValidator.validateFieldsCodeItem(csvFieldsList);
             codeChanges.setCsvFields(csvFieldsList);
         }
 
@@ -375,7 +379,7 @@ public class ClassificationController {
 
         if (!csvFields.isEmpty())  {
             List<String> csvFieldsList = getCsvFieldsList(csvFields);
-            validateFieldsList(CodeItem.class, csvFieldsList);
+            csvFieldsValidator.validateFieldsCodeItem(csvFieldsList);
             codeList.setCsvFields(csvFieldsList);
         }
 
@@ -402,7 +406,7 @@ public class ClassificationController {
 
         if (!csvFields.isEmpty())  {
             List<String> csvFieldsList = getCsvFieldsList(csvFields);
-            validateFieldsList(CodeItem.class, csvFieldsList);
+            csvFieldsValidator.validateFieldsCodeItem(csvFieldsList);
             codeList.setCsvFields(csvFieldsList);
         }
 
@@ -435,7 +439,7 @@ public class ClassificationController {
 
         if (!csvFields.isEmpty())  {
             List<String> csvFieldsList = getCsvFieldsList(csvFields);
-            validateFieldsList(CorrespondenceItem.RangedCorrespondenceItem.class, csvFieldsList);
+            csvFieldsValidator.validateFieldsCorrespondenceItem(csvFieldsList);
             correspondenceList.setCsvFields(csvFieldsList);
         }
 
@@ -456,7 +460,7 @@ public class ClassificationController {
 
         if (!csvFields.isEmpty())  {
             List<String> csvFieldsList = getCsvFieldsList(csvFields);
-            validateFieldsList(CorrespondenceItem.RangedCorrespondenceItem.class, csvFieldsList);
+            csvFieldsValidator.validateFieldsCorrespondenceItem(csvFieldsList);
             correspondenceList.setCsvFields(csvFieldsList);
         }
 
@@ -559,13 +563,6 @@ public class ClassificationController {
         return Arrays.asList(csvFields.split(","));
     }
 
-    private void validateFieldsList(Class<?> clazz, List<String> csvFields)  {
-        CsvSchema schema = new CsvMapper().schemaFor(clazz);
-        List<String> fieldsNotFound = csvFields.stream().filter(s -> schema.column(s) == null).collect(toList());
-        if(!fieldsNotFound.isEmpty()) {
-            throw new IllegalArgumentException("field(s) not found: " + String.join(",", fieldsNotFound));
-        }
-    }
 
     @InitBinder
     public void initBinder(WebDataBinder binder) {

--- a/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
@@ -561,9 +561,9 @@ public class ClassificationController {
 
     private void validateFieldsList(Class<?> clazz, List<String> csvFields)  {
         CsvSchema schema = new CsvMapper().schemaFor(clazz);
-        List<String> FieldsNotFound = csvFields.stream().filter(s -> schema.column(s) == null).collect(toList());
-        if(!FieldsNotFound.isEmpty()) {
-            throw new IllegalArgumentException("field(s) not found: " + String.join(",", FieldsNotFound));
+        List<String> fieldsNotFound = csvFields.stream().filter(s -> schema.column(s) == null).collect(toList());
+        if(!fieldsNotFound.isEmpty()) {
+            throw new IllegalArgumentException("field(s) not found: " + String.join(",", fieldsNotFound));
         }
     }
 

--- a/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
@@ -6,6 +6,7 @@ import java.beans.PropertyEditorSupport;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -200,7 +201,7 @@ public class ClassificationController {
             // @formatter:off
                 @RequestParam(value = "query") String query,
                 @RequestParam(value = "ssbSection", required = false) String ssbSection,
-                @RequestParam(value = "includeCodelists", defaultValue = "false") boolean includeCodelists, 
+                @RequestParam(value = "includeCodelists", defaultValue = "false") boolean includeCodelists,
                 Pageable pageable, PagedResourcesAssembler<SolrSearchResult> assembler) {
             // @formatter:on
         Link self = new Link(getCurrentRequest(), Link.REL_SELF);
@@ -258,6 +259,7 @@ public class ClassificationController {
                           @RequestParam(value = "from") @DateTimeFormat(pattern = RestConstants.DATE_FORMAT) LocalDate from,
                           @RequestParam(value = "to", required = false) @DateTimeFormat(pattern = RestConstants.DATE_FORMAT) LocalDate to,
                           @RequestParam(value = "csvSeparator", defaultValue = ",") String csvSeparator,
+                          @RequestParam(value = "csvFields", defaultValue = "") String csvFields,
                           @RequestParam(value = "selectLevel", required = false) String selectLevel,
                           @RequestParam(value = "selectCodes", required = false) String selectCodes,
                           @RequestParam(value = "presentationNamePattern", required = false) String presentationNamePattern,
@@ -265,15 +267,21 @@ public class ClassificationController {
                           @RequestParam(value = "includeFuture", defaultValue = "false") Boolean includeFuture
                           ) {
             // @formatter:on
-        return codesInternal(id, new DateRangeHolder(from, to), csvSeparator, selectLevel, selectCodes,
+        CodeList codeList = codesInternal(id, new DateRangeHolder(from, to), csvSeparator, selectLevel, selectCodes,
                 presentationNamePattern, language, includeFuture);
+
+        if (!csvFields.isEmpty())  {
+            codeList.setCsvFields(getCsvFieldsList(csvFields));
+        }
+        return codeList;
     }
 
     @RequestMapping(value = "/classifications/{id}/codesAt", method = RequestMethod.GET)
-    public CodeList codesAt(@PathVariable Long id,
+    public Object codesAt(@PathVariable Long id,
             // @formatter:off
                           @RequestParam(value = "date") @DateTimeFormat(pattern = RestConstants.DATE_FORMAT) LocalDate date,
                           @RequestParam(value = "csvSeparator", defaultValue = ",") String csvSeparator,
+                          @RequestParam(value = "csvFields", defaultValue = "") String csvFields,
                           @RequestParam(value = "selectLevel", required = false) String selectLevel,
                           @RequestParam(value = "selectCodes", required = false) String selectCodes,
                           @RequestParam(value = "presentationNamePattern", required = false) String presentationNamePattern,
@@ -281,8 +289,15 @@ public class ClassificationController {
                           @RequestParam(value = "includeFuture", defaultValue = "false") Boolean includeFuture
                           ) {
             // @formatter:on
-        return codesInternal(id, new DateRangeHolder(date), csvSeparator, selectLevel, selectCodes,
+
+        CodeList codeList = codesInternal(id, new DateRangeHolder(date), csvSeparator, selectLevel, selectCodes,
                 presentationNamePattern, language, includeFuture);
+
+        if (!csvFields.isEmpty())  {
+            codeList.setCsvFields(getCsvFieldsList(csvFields));
+        }
+
+        return codeList;
     }
 
     private CodeList codesInternal(Long id, DateRangeHolder dateRangeHolder, String csvSeparator, String selectLevel,
@@ -304,6 +319,7 @@ public class ClassificationController {
                           @RequestParam(value = "from") @DateTimeFormat(pattern = RestConstants.DATE_FORMAT) LocalDate from,
                           @RequestParam(value = "to", required = false) @DateTimeFormat(pattern = RestConstants.DATE_FORMAT) LocalDate to,
                           @RequestParam(value = "csvSeparator", defaultValue = ",") String csvSeparator,
+                          @RequestParam(value = "csvFields", defaultValue = "") String csvFields,
                           @RequestParam(value = "language", defaultValue = "nb") Language language,
                           @RequestParam(value = "includeFuture", defaultValue = "false") Boolean includeFuture) {
             // @formatter:on
@@ -315,6 +331,11 @@ public class ClassificationController {
         for (CorrespondenceTable changeTable : changeTables) {
             codeChanges = codeChanges.merge(codeChanges.convert(changeTable, language));
         }
+
+        if (!csvFields.isEmpty())  {
+            codeChanges.setCsvFields(getCsvFieldsList(csvFields));
+        }
+
         return codeChanges;
     }
 
@@ -325,6 +346,7 @@ public class ClassificationController {
                           @RequestParam(value = "from") @DateTimeFormat(pattern = RestConstants.DATE_FORMAT) LocalDate from,
                           @RequestParam(value = "to", required = false) @DateTimeFormat(pattern = RestConstants.DATE_FORMAT) LocalDate to,
                           @RequestParam(value = "csvSeparator", defaultValue = ",") String csvSeparator,
+                          @RequestParam(value = "csvFields", defaultValue = "") String csvFields,
                           @RequestParam(value = "level", required = false) String selectLevel,
                           @RequestParam(value = "selectCodes", required = false) String selectCodes,
                           @RequestParam(value = "presentationNamePattern", required = false) String presentationNamePattern,
@@ -332,8 +354,15 @@ public class ClassificationController {
                           @RequestParam(value = "includeFuture", defaultValue = "false") Boolean includeFuture
                           ) {
             // @formatter:on
-        return variantInternal(id, variantName, new DateRangeHolder(from, to), csvSeparator, selectLevel, selectCodes,
+        CodeList codeList = variantInternal(id, variantName, new DateRangeHolder(from, to), csvSeparator, selectLevel, selectCodes,
                 presentationNamePattern, language, includeFuture);
+
+        if (!csvFields.isEmpty())  {
+            codeList.setCsvFields(getCsvFieldsList(csvFields));
+        }
+
+        return codeList;
+
     }
 
     @RequestMapping(value = "/classifications/{id}/variantAt", method = RequestMethod.GET)
@@ -342,6 +371,7 @@ public class ClassificationController {
                           @RequestParam(value = "variantName") String variantName,
                           @RequestParam(value = "date", required = false) @DateTimeFormat(pattern = RestConstants.DATE_FORMAT) LocalDate date,
                           @RequestParam(value = "csvSeparator", defaultValue = ",") String csvSeparator,
+                          @RequestParam(value = "csvFields", defaultValue = "") String csvFields,
                           @RequestParam(value = "level", required = false) String selectLevel,
                           @RequestParam(value = "selectCodes", required = false) String selectCodes,
                           @RequestParam(value = "presentationNamePattern", required = false) String presentationNamePattern,
@@ -349,9 +379,17 @@ public class ClassificationController {
                           @RequestParam(value = "includeFuture", defaultValue = "false") Boolean includeFuture
                           ) {
             // @formatter:on
-        return variantInternal(id, variantName, new DateRangeHolder(date), csvSeparator, selectLevel, selectCodes,
+        CodeList codeList = variantInternal(id, variantName, new DateRangeHolder(date), csvSeparator, selectLevel, selectCodes,
                 presentationNamePattern, language, includeFuture);
+
+        if (!csvFields.isEmpty())  {
+            codeList.setCsvFields(getCsvFieldsList(csvFields));
+        }
+
+        return codeList;
     }
+
+
 
     private CodeList variantInternal(Long id, String variantName, DateRangeHolder dateRangeHolder, String csvSeparator,
             String selectLevel, String selectCodes, String presentationNamePattern, Language language, Boolean includeFuture) {
@@ -369,10 +407,17 @@ public class ClassificationController {
                           @RequestParam(value = "from") @DateTimeFormat(pattern = RestConstants.DATE_FORMAT) LocalDate from,
                           @RequestParam(value = "to", required = false) @DateTimeFormat(pattern = RestConstants.DATE_FORMAT) LocalDate to,
                           @RequestParam(value = "csvSeparator", defaultValue = ",") String csvSeparator,
+                          @RequestParam(value = "csvFields", defaultValue = "") String csvFields,
                           @RequestParam(value = "language", defaultValue = "nb") Language language,
                           @RequestParam(value = "includeFuture", defaultValue = "false") Boolean includeFuture) {
             // @formatter:on
-        return correspondsInternal(id, targetClassificationId, new DateRangeHolder(from, to), csvSeparator, language, includeFuture);
+        CorrespondenceItemList correspondenceList = correspondsInternal(id, targetClassificationId, new DateRangeHolder(from, to), csvSeparator, language, includeFuture);
+
+        if (!csvFields.isEmpty())  {
+            correspondenceList.setCsvFields(Arrays.asList(csvFields.split(",")));
+        }
+
+        return correspondenceList;
     }
 
     @RequestMapping(value = "/classifications/{id}/correspondsAt", method = RequestMethod.GET)
@@ -381,10 +426,16 @@ public class ClassificationController {
                           @RequestParam(value = "targetClassificationId") Long targetClassificationId,
                           @RequestParam(value = "date", required = false) @DateTimeFormat(pattern = RestConstants.DATE_FORMAT) LocalDate date,
                           @RequestParam(value = "csvSeparator", defaultValue = ",") String csvSeparator,
+                          @RequestParam(value = "csvFields", defaultValue = "") String csvFields,
                           @RequestParam(value = "language", defaultValue = "nb") Language language,
                           @RequestParam(value = "includeFuture", defaultValue = "false") Boolean includeFuture) {
             // @formatter:on
-        return correspondsInternal(id, targetClassificationId, new DateRangeHolder(date), csvSeparator, language, includeFuture);
+        CorrespondenceItemList correspondenceList = correspondsInternal(id, targetClassificationId, new DateRangeHolder(date), csvSeparator, language, includeFuture);
+
+        if (!csvFields.isEmpty())  {
+            correspondenceList.setCsvFields(Arrays.asList(csvFields.split(",")));
+        }
+        return correspondenceList;
     }
 
     private CorrespondenceItemList correspondsInternal(Long id, Long targetClassificationId,
@@ -477,6 +528,10 @@ public class ClassificationController {
 
     private String extractSsbSection(String ssbSection) {
         return Strings.isNullOrEmpty(ssbSection) ? null : ssbSection;
+    }
+
+    private List<String> getCsvFieldsList(String csvFields) {
+        return Arrays.asList(csvFields.split(","));
     }
 
     @InitBinder

--- a/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
@@ -561,8 +561,8 @@ public class ClassificationController {
 
     private void validateFieldsList(Class<?> clazz, List<String> csvFields)  {
         CsvMapper mapper = new CsvMapper();
-        CsvSchema fullSchema = mapper.schemaFor(clazz);
-        List<String> notFound = csvFields.stream().filter(s -> fullSchema.column(s) == null).collect(toList());
+        CsvSchema schema = mapper.schemaFor(clazz);
+        List<String> notFound = csvFields.stream().filter(s -> schema.column(s) == null).collect(toList());
         if(!notFound.isEmpty()) {
             throw new IllegalArgumentException("field(s) not found: " + String.join(",", notFound));
         }

--- a/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
@@ -277,7 +277,7 @@ public class ClassificationController {
     }
 
     @RequestMapping(value = "/classifications/{id}/codesAt", method = RequestMethod.GET)
-    public Object codesAt(@PathVariable Long id,
+    public CodeList codesAt(@PathVariable Long id,
             // @formatter:off
                           @RequestParam(value = "date") @DateTimeFormat(pattern = RestConstants.DATE_FORMAT) LocalDate date,
                           @RequestParam(value = "csvSeparator", defaultValue = ",") String csvSeparator,

--- a/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
@@ -3,7 +3,6 @@ package no.ssb.klass.api.controllers;
 import static java.util.stream.Collectors.*;
 
 import java.beans.PropertyEditorSupport;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.LocalDate;

--- a/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
@@ -287,7 +287,7 @@ public class ClassificationController {
 
         if (!csvFields.isEmpty())  {
             List<String> csvFieldsList = getCsvFieldsList(csvFields);
-            csvFieldsValidator.validateFieldsChangeItemSchema( csvFieldsList);
+            csvFieldsValidator.validateFieldsCodeItem( csvFieldsList);
             codeList.setCsvFields(csvFieldsList);
         }
         return codeList;
@@ -352,7 +352,7 @@ public class ClassificationController {
 
         if (!csvFields.isEmpty())  {
             List<String> csvFieldsList = getCsvFieldsList(csvFields);
-            csvFieldsValidator.validateFieldsCodeItem(csvFieldsList);
+            csvFieldsValidator.validateFieldsChangeItemSchema(csvFieldsList);
             codeChanges.setCsvFields(csvFieldsList);
         }
 

--- a/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/controllers/ClassificationController.java
@@ -560,11 +560,10 @@ public class ClassificationController {
     }
 
     private void validateFieldsList(Class<?> clazz, List<String> csvFields)  {
-        CsvMapper mapper = new CsvMapper();
-        CsvSchema schema = mapper.schemaFor(clazz);
-        List<String> notFound = csvFields.stream().filter(s -> schema.column(s) == null).collect(toList());
-        if(!notFound.isEmpty()) {
-            throw new IllegalArgumentException("field(s) not found: " + String.join(",", notFound));
+        CsvSchema schema = new CsvMapper().schemaFor(clazz);
+        List<String> FieldsNotFound = csvFields.stream().filter(s -> schema.column(s) == null).collect(toList());
+        if(!FieldsNotFound.isEmpty()) {
+            throw new IllegalArgumentException("field(s) not found: " + String.join(",", FieldsNotFound));
         }
     }
 

--- a/klass-api/src/main/java/no/ssb/klass/api/controllers/validators/CsvFieldsValidator.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/controllers/validators/CsvFieldsValidator.java
@@ -1,0 +1,40 @@
+package no.ssb.klass.api.controllers.validators;
+
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvSchema;
+import no.ssb.klass.api.dto.CodeChangeItem;
+import no.ssb.klass.api.dto.CodeItem;
+import no.ssb.klass.api.dto.CorrespondenceItem;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Component
+public class CsvFieldsValidator {
+
+    private final CsvSchema correspondenceItemSchema = new CsvMapper().schemaFor(CorrespondenceItem.RangedCorrespondenceItem.class);
+    private final CsvSchema codeItemSchema = new CsvMapper().schemaFor(CodeItem.class);
+    private final CsvSchema codeChangeItemSchema = new CsvMapper().schemaFor(CodeChangeItem.class);
+
+    public void validateFieldsCorrespondenceItem(List<String> csvFields)  {
+        List<String> fieldsNotFound = csvFields.stream().filter(s -> correspondenceItemSchema.column(s) == null).collect(toList());
+        if(!fieldsNotFound.isEmpty()) {
+            throw new IllegalArgumentException("CorrespondenceList does not contain the following field(s): " + String.join(",", fieldsNotFound));
+        }
+    }
+    public void validateFieldsCodeItem(List<String> csvFields)  {
+        List<String> fieldsNotFound = csvFields.stream().filter(s -> codeItemSchema.column(s) == null).collect(toList());
+        if(!fieldsNotFound.isEmpty()) {
+            throw new IllegalArgumentException("CorrespondenceList does not contain the following field(s): " + String.join(",", fieldsNotFound));
+        }
+    }
+    public void validateFieldsChangeItemSchema(List<String> csvFields)  {
+        List<String> fieldsNotFound = csvFields.stream().filter(s -> codeChangeItemSchema.column(s) == null).collect(toList());
+        if(!fieldsNotFound.isEmpty()) {
+            throw new IllegalArgumentException("CorrespondenceList does not contain the following field(s): " + String.join(",", fieldsNotFound));
+        }
+    }
+
+}

--- a/klass-api/src/main/java/no/ssb/klass/api/converters/CodeChangeListCsvConverter.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/converters/CodeChangeListCsvConverter.java
@@ -20,7 +20,7 @@ public class CodeChangeListCsvConverter extends AbstractCsvConverter<CodeChangeL
     @Override
     protected void writeInternal(CodeChangeList codeChangeList, HttpOutputMessage outputMessage) throws IOException {
         Charset charset = selectCharsetAndUpdateOutput(outputMessage);
-        ObjectWriter writer = createWriter(CodeChangeItem.class, codeChangeList.getCsvSeparator());
+        ObjectWriter writer = createWriter(CodeChangeItem.class, codeChangeList.getCsvSeparator(), codeChangeList.getCsvFields());
         writer.writeValue(new OutputStreamWriter(outputMessage.getBody(), charset), codeChangeList.getCodeChanges());
     }
 }

--- a/klass-api/src/main/java/no/ssb/klass/api/converters/CodeListCsvConverter.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/converters/CodeListCsvConverter.java
@@ -19,7 +19,7 @@ public class CodeListCsvConverter extends AbstractCsvConverter<CodeList> {
     @Override
     protected void writeInternal(CodeList codeList, HttpOutputMessage outputMessage) throws IOException {
         Charset charset = selectCharsetAndUpdateOutput(outputMessage);
-        ObjectWriter writer = createWriter(codeList.codeItemsJavaType(), codeList.getCsvSeparator());
+        ObjectWriter writer = createWriter(codeList.codeItemsJavaType(), codeList.getCsvSeparator(), codeList.getCsvFields());
         writer.writeValue(new OutputStreamWriter(outputMessage.getBody(), charset), codeList.getCodes());
     }
 }

--- a/klass-api/src/main/java/no/ssb/klass/api/converters/CorrespondenceItemListCsvConverter.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/converters/CorrespondenceItemListCsvConverter.java
@@ -21,7 +21,7 @@ public class CorrespondenceItemListCsvConverter extends AbstractCsvConverter<Cor
             throws IOException {
         Charset charset = selectCharsetAndUpdateOutput(outputMessage);
         ObjectWriter writer = createWriter(correspondenceItemList.classificationItemsJavaType(), correspondenceItemList
-                .getCsvSeparator());
+                .getCsvSeparator(),  correspondenceItemList.getCsvFields());
         writer.writeValue(new OutputStreamWriter(outputMessage.getBody(), charset), correspondenceItemList
                 .getCorrespondenceItems());
     }

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/CodeChangeList.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/CodeChangeList.java
@@ -18,6 +18,7 @@ import no.ssb.klass.core.model.Language;
 public class CodeChangeList {
     private final char csvSeparator;
     private final List<CodeChangeItem> codeChanges;
+    private List<String> csvFields;
 
     public CodeChangeList(String csvSeparator) {
         if (csvSeparator.toCharArray().length != 1) {
@@ -41,6 +42,16 @@ public class CodeChangeList {
     @JsonIgnore
     public char getCsvSeparator() {
         return csvSeparator;
+    }
+
+    @JsonIgnore
+    public List<String> getCsvFields() {
+        return csvFields;
+    }
+
+    @JsonIgnore
+    public void setCsvFields(List<String> csvFields) {
+        this.csvFields = csvFields;
     }
 
     public CodeChangeList convert(CorrespondenceTable correspondenceTable, Language language) {

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/CodeList.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/CodeList.java
@@ -33,6 +33,7 @@ public class CodeList {
     private final List<RangedCodeItem> codeItems;
     private final Boolean includeFuture;
     private final DateRange dateRange;
+    private List<String> csvFields;
 
     public CodeList(String csvSeparator, boolean displayWithValidRange, DateRange dateRange, Boolean includeFuture) {
         if (csvSeparator.toCharArray().length != 1) {
@@ -65,6 +66,16 @@ public class CodeList {
     @JsonIgnore
     public char getCsvSeparator() {
         return csvSeparator;
+    }
+
+    @JsonIgnore
+    public List<String> getCsvFields() {
+        return csvFields;
+    }
+
+    @JsonIgnore
+    public void setCsvFields(List<String> csvFields) {
+        this.csvFields = csvFields;
     }
 
     public CodeList merge(CodeList other) {

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/CorrespondenceItemList.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/CorrespondenceItemList.java
@@ -17,6 +17,7 @@ public class CorrespondenceItemList {
     private final boolean displayWithValidRange;
     private final List<RangedCorrespondenceItem> correspondenceItems;
     private final Boolean includeFuture;
+    private List<String> csvFields;
 
     public CorrespondenceItemList(String csvSeparator, boolean displayWithValidRange, boolean includeFuture) {
         if (csvSeparator.toCharArray().length != 1) {
@@ -49,6 +50,17 @@ public class CorrespondenceItemList {
     public char getCsvSeparator() {
         return csvSeparator;
     }
+
+    @JsonIgnore
+    public List<String> getCsvFields() {
+        return csvFields;
+    }
+
+    @JsonIgnore
+    public void setCsvFields(List<String> csvFields) {
+        this.csvFields = csvFields;
+    }
+
 
     public CorrespondenceItemList convert(List<CorrespondenceDto> correspondences) {
         return newList(correspondences.stream()

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationResource.java
@@ -95,14 +95,14 @@ public class ClassificationResource extends ClassificationSummaryResource {
 
     private Link createVariantAtRelation(Long id) {
         ControllerLinkBuilder linkBuilder = linkTo(ControllerLinkBuilder.methodOn(ClassificationController.class).variantAt(id, "name",
-                LocalDate.now(), ",", "level", "selectCodes", "presentationNamePattern", Language.getDefault(), null));
+                LocalDate.now(), ",", null, "level", "selectCodes", "presentationNamePattern", Language.getDefault(), null));
         return new Link(createUriTemplate(linkBuilder, "variantName", date(), "csvSeparator", "level", "selectCodes",
                 "presentationNamePattern"), "variantAt");
     }
 
     private Link createVariantRelation(Long id) {
         ControllerLinkBuilder linkBuilder = linkTo(ControllerLinkBuilder.methodOn(ClassificationController.class).variant(id, "name",
-                LocalDate.now(), LocalDate.now(), ",", "level", "selectCodes", "presentationNamePattern", Language
+                LocalDate.now(), LocalDate.now(), ",",null, "level", "selectCodes", "presentationNamePattern", Language
                         .getDefault(), null));
         return new Link(createUriTemplate(linkBuilder, "variantName", from(), to(), "csvSeparator", "level",
                 "selectCodes", "presentationNamePattern"), "variant");
@@ -110,34 +110,34 @@ public class ClassificationResource extends ClassificationSummaryResource {
 
     private Link createCodesAtRelation(Long id) {
         ControllerLinkBuilder linkBuilder = linkTo(ControllerLinkBuilder.methodOn(ClassificationController.class).codesAt(id, LocalDate.now(),
-                ",", "level", "selectCodes", "presentationNamePattern", Language.getDefault(), null));
+                ",",null, "level", "selectCodes", "presentationNamePattern", Language.getDefault(), null));
         return new Link(createUriTemplate(linkBuilder, date(), "csvSeparator", "level", "selectCodes",
                 "presentationNamePattern"), "codesAt");
     }
 
     private Link createCodesRelation(Long id) {
         ControllerLinkBuilder linkBuilder = linkTo(ControllerLinkBuilder.methodOn(ClassificationController.class).codes(id, LocalDate.now(),
-                LocalDate.now(), ",", "level", "selectCodes", "presentationNamePattern", Language.getDefault(), null));
+                LocalDate.now(), ",",null, "level", "selectCodes", "presentationNamePattern", Language.getDefault(), null));
         return new Link(createUriTemplate(linkBuilder, from(), to(), "csvSeparator", "level", "selectCodes",
                 "presentationNamePattern"), "codes");
     }
 
     private Link createChangesRelation(Long id) {
         ControllerLinkBuilder linkBuilder = linkTo(ControllerLinkBuilder.methodOn(ClassificationController.class).changes(id, LocalDate.now(),
-                LocalDate.now(), ",", Language.getDefault(), null));
+                LocalDate.now(), ",",null, Language.getDefault(), null));
         return new Link(createUriTemplate(linkBuilder, from(), to(), "csvSeparator"), "changes");
     }
 
     private Link createCorrespondsAtRelation(Long id) {
         ControllerLinkBuilder linkBuilder = linkTo(ControllerLinkBuilder.methodOn(ClassificationController.class).correspondsAt(id, 2L,
-                LocalDate.now(), ",", Language.getDefault(), null));
+                LocalDate.now(), ",",null, Language.getDefault(), null));
         return new Link(createUriTemplate(linkBuilder, "targetClassificationId", date(), "csvSeparator"),
                 "correspondsAt");
     }
 
     private Link createCorrespondsRelation(Long id) {
         ControllerLinkBuilder linkBuilder = linkTo(ControllerLinkBuilder.methodOn(ClassificationController.class).corresponds(id, 2L,
-                LocalDate.now(), LocalDate.now(), ",", Language.getDefault(), null));
+                LocalDate.now(), LocalDate.now(), ",",null, Language.getDefault(), null));
         return new Link(createUriTemplate(linkBuilder, "targetClassificationId", from(), to(), "csvSeparator"),
                 "corresponds");
     }

--- a/klass-api/src/test/java/no/ssb/klass/api/ApiDocumentation.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/ApiDocumentation.java
@@ -442,7 +442,7 @@ public class ApiDocumentation {
         List<CodeDto> codes = createKommuneInndelingCodes(dateRange);
         when(classificationServiceMock.findClassificationCodes(any(), any(), any(), any())).thenReturn(codes);
         // @formatter:off
-        this.mockMvc.perform(getWithContextUri("/classifications/" + CLASS_ID_KOMMUNEINNDELING + "/codes?from=2014-01-01&to=2015-01-01&csvSeparator=;"
+        this.mockMvc.perform(getWithContextUri("/classifications/" + CLASS_ID_KOMMUNEINNDELING + "/codes?from=2014-01-01&to=2015-01-01&csvSeparator=;&csvFields=name,code"
                 + "&selectLevel=1&selectCodes=01*&presentationNamePattern={code}-{name}&language=nb&includeFuture=true")
                 .accept("text/csv"))
                 .andDo(this.documentationHandler
@@ -451,6 +451,7 @@ public class ApiDocumentation {
                                 fromParameterDescription(),
                                 toParameterDescription(),
                                 csvSeparatorParameterDescription(),
+                                csvFieldsParameterDescription(),
                                 selectCodesParameterDescription(),
                                 selectLevelParameterDescription(),
                                 presentationNamePatternParameterDescription(),
@@ -494,12 +495,13 @@ public class ApiDocumentation {
         when(classificationServiceMock.findClassificationCodes(any(), any(), any(), any())).thenReturn(codes);
         // @formatter:off
         this.mockMvc.perform(getWithContextUri("/classifications/" + CLASS_ID_KOMMUNEINNDELING
-                + "/codesAt?date=2015-01-01&csvSeparator=;&selectLevel=1&selectCodes=01*"
+                + "/codesAt?date=2015-01-01&csvSeparator=;&csvFields=name,code&selectLevel=1&selectCodes=01*"
                 + "&presentationNamePattern={code}-{name}&language=nb&includeFuture=true").accept("text/csv"))
                 .andDo(this.documentationHandler.document(
                         requestParameters(
                                 dateParameterDescription(),
                                 csvSeparatorParameterDescription(),
+                                csvFieldsParameterDescription(),
                                 selectCodesParameterDescription(),
                                 selectLevelParameterDescription(),
                                 presentationNamePatternParameterDescription(),
@@ -549,7 +551,7 @@ public class ApiDocumentation {
         this.mockMvc.perform(
                 getWithContextUri("/classifications/" + CLASS_ID_GREENHOUSE_GASES
                         + "/variant?variantName=Klimagasser"
-                        + "&from=2014-01-01&to=2015-01-01&csvSeparator=;&selectLevel=1&selectCodes=01*"
+                        + "&from=2014-01-01&to=2015-01-01&csvSeparator=;&csvFields=name,code&selectLevel=1&selectCodes=01*"
                         + "&presentationNamePattern={code}-{name}&language=nb&includeFuture=true")
                         .accept("text/csv"))
                 .andDo(this.documentationHandler = document("{method-name}",
@@ -561,6 +563,7 @@ public class ApiDocumentation {
                                 fromParameterDescription(),
                                 toParameterDescription(),
                                 csvSeparatorParameterDescription(),
+                                csvFieldsParameterDescription(),
                                 selectCodesParameterDescription(),
                                 selectLevelParameterDescription(),
                                 presentationNamePatternParameterDescription(),
@@ -610,7 +613,7 @@ public class ApiDocumentation {
         this.mockMvc.perform(
                 getWithContextUri("/classifications/" + CLASS_ID_GREENHOUSE_GASES
                         + "/variantAt?variantName=Klimagasser"
-                        + "&date=2015-01-01&csvSeparator=;&selectLevel=1&selectCodes=01*"
+                        + "&date=2015-01-01&csvSeparator=;&csvFields=name,code&selectLevel=1&selectCodes=01*"
                         + "&presentationNamePattern={code}-{name}&language=nb&includeFuture=true").accept("text/csv"))
                 .andDo(this.documentationHandler = document("{method-name}",
                         preprocessRequest(prettyPrint()),
@@ -620,6 +623,7 @@ public class ApiDocumentation {
                                 variantNameParameterDescription(),
                                 dateParameterDescription(),
                                 csvSeparatorParameterDescription(),
+                                csvFieldsParameterDescription(),
                                 selectCodesParameterDescription(),
                                 selectLevelParameterDescription(),
                                 presentationNamePatternParameterDescription(),
@@ -715,7 +719,7 @@ public class ApiDocumentation {
         this.mockMvc.perform(
                 getWithContext("/classifications/" + CLASS_ID_KOMMUNEINNDELING
                         + "/corresponds?targetClassificationId=" + CLASS_ID_BYDELSINNDELING
-                        + "&from=2014-01-01&to=2016-01-01&csvSeparator=;"
+                        + "&from=2014-01-01&to=2016-01-01&csvSeparator=;&csvFields=name,code"
                         + "&language=nb&includeFuture=true").accept("text/csv"))
                 .andDo(this.documentationHandler = document("{method-name}",
                         preprocessRequest(prettyPrint()),
@@ -725,6 +729,7 @@ public class ApiDocumentation {
                                 targetClassificationIdParameterDescription(),
                                 fromParameterDescription(),
                                 toParameterDescription(),
+                                csvFieldsParameterDescription(),
                                 csvSeparatorParameterDescription(),
                                 languageDescription(),
                                 includeFutureDescription(""))))
@@ -757,7 +762,7 @@ public class ApiDocumentation {
         // @formatter:off
         this.mockMvc.perform(
                 getWithContext("/classifications/" + CLASS_ID_KOMMUNEINNDELING
-                        + "/correspondsAt?targetClassificationId=" + CLASS_ID_BYDELSINNDELING + "&date=2016-01-01&csvSeparator=;"
+                        + "/correspondsAt?targetClassificationId=" + CLASS_ID_BYDELSINNDELING + "&date=2016-01-01&csvSeparator=;&csvFields=name,code"
                         + "&language=nb&includeFuture=true").accept("text/csv"))
                 .andDo(this.documentationHandler = document("{method-name}",
                         preprocessRequest(prettyPrint()),
@@ -767,6 +772,7 @@ public class ApiDocumentation {
                                 targetClassificationIdParameterDescription(),
                                 dateParameterDescription(),
                                 csvSeparatorParameterDescription(),
+                                csvFieldsParameterDescription(),
                                 languageDescription(),
                                 includeFutureDescription(""))))
                 .andExpect(status().isOk());
@@ -877,6 +883,22 @@ public class ApiDocumentation {
         this.mockMvc.perform(
                 getWithContext("/classifications/" + CLASS_ID_KOMMUNEINNDELING
                         + "/codes?from=2014-01-01&to=2015-01-01&csvSeparator=;")
+                        .accept("text/csv"))
+                .andDo(this.documentationHandler = document("{method-name}",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(/*prettyPrint()*/)))
+                .andExpect(status().isOk());
+        // @formatter:on
+    }
+    @Test
+    public void csvFieldsExample() throws Exception {
+        DateRange dateRange = DateRange.create("2014-01-01", "2015-01-01");
+        when(classificationServiceMock.findClassificationCodes(any(), any(), any(), any())).thenReturn(
+                createKommuneInndelingCodes(dateRange));
+        // @formatter:off
+        this.mockMvc.perform(
+                getWithContext("/classifications/" + CLASS_ID_KOMMUNEINNDELING
+                        + "/codes?from=2014-01-01&to=2015-01-01&csvSeparator=;&csvFields=name,code")
                         .accept("text/csv"))
                 .andDo(this.documentationHandler = document("{method-name}",
                         preprocessRequest(prettyPrint()),
@@ -1106,6 +1128,10 @@ public class ApiDocumentation {
     private ParameterDescriptor csvSeparatorParameterDescription() {
         return parameterWithName("csvSeparator").description(
                 "[Optional] specifies separator to be used for csv format. For details see <<_csvseparator, csvSeparator>>");
+    }
+    private ParameterDescriptor csvFieldsParameterDescription() {
+        return parameterWithName("csvFields").description(
+                "[Optional] specifies which fields should be included in the csv output. For details see <<_csvfields, csvfields>>");
     }
 
     private ParameterDescriptor selectCodesParameterDescription() {

--- a/klass-api/src/test/java/no/ssb/klass/api/ApiDocumentation.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/ApiDocumentation.java
@@ -719,7 +719,7 @@ public class ApiDocumentation {
         this.mockMvc.perform(
                 getWithContext("/classifications/" + CLASS_ID_KOMMUNEINNDELING
                         + "/corresponds?targetClassificationId=" + CLASS_ID_BYDELSINNDELING
-                        + "&from=2014-01-01&to=2016-01-01&csvSeparator=;&csvFields=name,code"
+                        + "&from=2014-01-01&to=2016-01-01&csvSeparator=;&csvFields=sourceCode,sourceName"
                         + "&language=nb&includeFuture=true").accept("text/csv"))
                 .andDo(this.documentationHandler = document("{method-name}",
                         preprocessRequest(prettyPrint()),
@@ -762,7 +762,7 @@ public class ApiDocumentation {
         // @formatter:off
         this.mockMvc.perform(
                 getWithContext("/classifications/" + CLASS_ID_KOMMUNEINNDELING
-                        + "/correspondsAt?targetClassificationId=" + CLASS_ID_BYDELSINNDELING + "&date=2016-01-01&csvSeparator=;&csvFields=name,code"
+                        + "/correspondsAt?targetClassificationId=" + CLASS_ID_BYDELSINNDELING + "&date=2016-01-01&csvSeparator=;&csvFields=sourceCode,sourceName"
                         + "&language=nb&includeFuture=true").accept("text/csv"))
                 .andDo(this.documentationHandler = document("{method-name}",
                         preprocessRequest(prettyPrint()),

--- a/klass-api/src/test/java/no/ssb/klass/api/config/MockConfig.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/config/MockConfig.java
@@ -52,6 +52,11 @@ public class MockConfig {
         return Mockito.mock(UserService.class);
     }
 
+    @Bean
+    private CsvFieldsValidator csvFieldsValidator() {
+        return new CsvFieldsValidator();
+    }
+
 
     @Bean
     public ClassificationController classificationController() {

--- a/klass-api/src/test/java/no/ssb/klass/api/config/MockConfig.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/config/MockConfig.java
@@ -1,5 +1,6 @@
 package no.ssb.klass.api.config;
 
+import no.ssb.klass.api.controllers.validators.CsvFieldsValidator;
 import no.ssb.klass.core.service.*;
 import no.ssb.klass.api.controllers.ClassificationController;
 import org.mockito.Mockito;
@@ -19,9 +20,12 @@ public class MockConfig {
     
     @Autowired
     private StatisticsService statisticsService;
-    @Autowired
 
+    @Autowired
     private UserService userService;
+
+    @Autowired
+    private CsvFieldsValidator csvFieldsValidator;
 
     @Bean
     public ClassificationService classificationService() {
@@ -48,8 +52,9 @@ public class MockConfig {
         return Mockito.mock(UserService.class);
     }
 
+
     @Bean
     public ClassificationController classificationController() {
-        return new ClassificationController(classificationService, subscriberService, searchService, statisticsService);
+        return new ClassificationController(classificationService, subscriberService, searchService, statisticsService, csvFieldsValidator);
     }
 }


### PR DESCRIPTION
Adding an extra parameter to 
```
codes, 
codesAt, 
variant, 
variantAt
corresponds, 
correspondsAt
```
that allow the user to specify what fields should be included in the Csv output
ex.

http://localhost:8080/api/klass/v1/classifications/1/codesAt.csv?date=2015-01-01&csvFields=code,name
```
"code","name"
"01","Oslo"
"02","Østfold"
"03","Follo"
"04","Romerike"
"05","Hedmark"
```


http://localhost:8080/api/klass/v1/classifications/1/corresponds.csv?targetClassificationId=2&from=2002-01-01&to=2007-01-01&csvFields=sourceCode,sourceName
```
"sourceCode","sourceName"
"01","Oslo"
"02","Østfold"
```
@m0rkeulv