### PR TITLE
Downgrade Vaadin framework to latest free version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <vaadin-spring-ext-security-version>0.0.7.RELEASE</vaadin-spring-ext-security-version>
         <objenesis-version>2.4</objenesis-version>
         <guava-version>19.0</guava-version>
-        <vaadin-version>7.7.25</vaadin-version>
+        <vaadin-version>7.7.17</vaadin-version>
         <vaadin.plugin.version>7.7.25</vaadin.plugin.version>
         <vaadin.testbench.api.version>7.7.14</vaadin.testbench.api.version>
         <vaadin.widgetset.mode>local</vaadin.widgetset.mode>


### PR DESCRIPTION
The main reason for upgrading in the first place was this https://vaadin.com/security/cve-2020-36320
But since we don't pay for extended support https://vaadin.com/support/vaadin-7-extended-maintenance and we don't use the `com.vaadin.data.validator.EmailValidator` we downgrade to latest free version.