### PR TITLE
Revert Vaadin upgrade

### DIFF
--- a/.maven.settings.xml
+++ b/.maven.settings.xml
@@ -1,16 +1,4 @@
 <settings>
-  <profiles>
-      <profile>
-          <id>nexus</id>
-          <repositories>
-              <repository>
-                  <id>ssb-repo</id>
-                  <name>Nexus</name>
-                  <url>https://nexus.ssb.no/repository/maven-public</url>
-              </repository>
-          </repositories>
-      </profile>
-  </profiles>
   <mirrors>
     <mirror>
       <id>maven-restletMirror</id>
@@ -19,4 +7,3 @@
     </mirror>
   </mirrors>
 </settings>
-

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,4 @@ build-all:
 
 .PHONY: run-klass-forvaltning-local
 run-klass-forvaltning-local:
-	pushd klass-forvaltning && mvn spring-boot\:run -Dspring-boot.run.profiles=h2-inmemory,embedded-solr,ad-offline,small-import && popd
+	pushd klass-forvaltning && mvn spring-boot\:run -P nexus -Dspring-boot.run.profiles=h2-inmemory,embedded-solr,ad-offline,small-import && popd

--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ IntelliJ is recommended, it makes it very easy to start spring boot applications
 
 Frontend may be accessed at:
 
-<http://localhost:8080/klassui>
+<http://localhost:8081/klassui>
 
 REST api documentation may be accessed at
 
-<http://localhost:8080/api/klass/v1/api-guide.html>
+<http://localhost:8081/api/klass/v1/api-guide.html>
 
 ## Troubleshooting
 

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <checkstyle-version>2.17</checkstyle-version>
         <solr-version>5.5.5</solr-version>
         <spring.version>4.3.7.RELEASE</spring.version>
-        <vaadin-spring-boot-starter-version>24.1.1</vaadin-spring-boot-starter-version>
+        <vaadin-spring-boot-starter-version>1.0.0</vaadin-spring-boot-starter-version>
         <vaadin-spring-ext-security-version>0.0.7.RELEASE</vaadin-spring-ext-security-version>
         <objenesis-version>2.4</objenesis-version>
         <guava-version>19.0</guava-version>

--- a/pom.xml
+++ b/pom.xml
@@ -145,4 +145,17 @@
         </pluginManagement>
     </build>
 
+  <profiles>
+      <profile>
+          <id>nexus</id>
+          <repositories>
+              <repository>
+                  <id>ssb-repo</id>
+                  <name>Nexus</name>
+                  <url>https://nexus.ssb.no/repository/maven-public</url>
+              </repository>
+          </repositories>
+      </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
- Use correct settings and profiles
- Revert "Bump vaadin-spring-boot-starter from 1.0.0 to 24.1.1 (#128)"
- Fix port in README
