### PR TITLE
Cascades deletion when importing new versions

### DIFF
--- a/klass-shared/src/main/java/no/ssb/klass/core/repository/CorrespondenceMapRepository.java
+++ b/klass-shared/src/main/java/no/ssb/klass/core/repository/CorrespondenceMapRepository.java
@@ -67,7 +67,10 @@ public interface CorrespondenceMapRepository extends CrudRepository<Corresponden
             + " INNER JOIN source.level slevel"
             + " INNER JOIN target.level tlevel"
             + " INNER JOIN map.correspondenceTable table "
-            + " WHERE table.deleted = true"
+            + " WHERE (table.deleted = true OR slevel.statisticalClassification.deleted = true"
+            + " OR tlevel.statisticalClassification.deleted = true OR"
+            + " slevel.statisticalClassification.classification.deleted = true "
+            + " OR tlevel.statisticalClassification.classification.deleted = true)"
             + " AND((slevel.statisticalClassification = :version  AND source in :deletedClassificationItems)"
             + "  OR (tlevel.statisticalClassification = :version  AND target in :deletedClassificationItems))")
     Set<CorrespondenceMap> findAllMapsUsingDeletedItems(@Param("version") StatisticalClassification classification,

--- a/klass-shared/src/main/java/no/ssb/klass/core/service/ClassificationServiceImpl.java
+++ b/klass-shared/src/main/java/no/ssb/klass/core/service/ClassificationServiceImpl.java
@@ -247,8 +247,8 @@ public class ClassificationServiceImpl implements ClassificationService {
             softDeletedItems.addAll(referencingClassificationItemRepository.findByReferenceInList(
                     deletedClassificationItems, true));
         }
-        softDeletedItems.forEach(item -> item.getLevel().getStatisticalClassification().deleteClassificationItem(item));
         softDeletedMaps.forEach(map -> map.getCorrespondenceTable().removeCorrespondenceMap(map));
+        softDeletedItems.forEach(item -> item.getLevel().getStatisticalClassification().deleteClassificationItem(item));
         classificationRepository.flush();
     }
 


### PR DESCRIPTION
Fixes STAT-603.
When importing new versions in Klass, orphan CorrespondenceMaps was stopping the import process. This was due to a mismatch between the elements that the UI and the backend knows of.
This PR cascades deletion checks between objects in order to fix the issue.

Co-authored by: @mmwinther