### PR TITLE
Add Makefile command for running Klass API locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,9 @@ run-klass-forvaltning-local-mariadb:
 	pushd klass-forvaltning && \
 	mvn spring-boot\:run -Dspring.profiles.active=mariadb,embedded-solr,frontend,skip-indexing,small-import,ad-offline -P nexus && \
 	popd
+
+# The environment variable KLASS_ENV_SECURITY_IGNORED must be set to "/**" in order to skip authentication
+run-klass-api-local-mariadb:
+	pushd klass-api && \
+	mvn spring-boot\:run -Dspring.profiles.active=mariadb,embedded-solr,mock-mailserver,skip-indexing,small-import,ad-offline -P nexus && \
+	popd

--- a/klass-api/src/main/resources/application.properties
+++ b/klass-api/src/main/resources/application.properties
@@ -62,3 +62,7 @@ spring.jpa.properties.hibernate.ejb.interceptor=no.ssb.klass.core.util.BaseEntit
 
 #context path for API docs
 klass.env.api.path=/api/klass
+
+# Security
+# Set to '/**' to skip authorization for local testing
+security.ignored=${klass.env.security.ignored}


### PR DESCRIPTION
When running the command, it is necessary to have the environment variable KLASS_ENV_SECURITY_IGNORED="/**" in order to skip authentication
