### PR TITLE
Fix vulnerable solr-core

### DIFF
--- a/klass-solr/pom.xml
+++ b/klass-solr/pom.xml
@@ -45,8 +45,16 @@
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-slf4j-impl</artifactId>
                 </exclusion>
-
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-common</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>3.3.3</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/klass-solr/pom.xml
+++ b/klass-solr/pom.xml
@@ -52,11 +52,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-common</artifactId>
-            <version>3.3.3</version>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>${commons-io-version}</version>


### PR DESCRIPTION
The package hadoop-common had a high severity vulnerability. Removed from solr-core since it is not used.