### PR TITLE
Add id element to the KlassResource

### DIFF
--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationFamilyResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationFamilyResource.java
@@ -18,13 +18,14 @@ import no.ssb.klass.core.model.Language;
 import no.ssb.klass.api.controllers.ClassificationController;
 
 @JacksonXmlRootElement(localName = "classificationFamily")
-@JsonPropertyOrder({"name", "classifications", "links"})
+@JsonPropertyOrder({"name", "id", "classifications", "links"})
 public class ClassificationFamilyResource extends KlassResource {
     private final String name;
     private final List<ClassificationSummaryResource> classifications;
 
     public ClassificationFamilyResource(ClassificationFamily classificationFamily, Language language, String ssbSection,
             ClassificationType classificationType) {
+        super(classificationFamily.getId());
         this.name = classificationFamily.getName(language);
         List<ClassificationSeries> classifications = classificationFamily
                 .getClassificationSeriesBySectionAndClassificationType(ssbSection, classificationType, true);

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationFamilySummaryResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationFamilySummaryResource.java
@@ -11,12 +11,13 @@ import no.ssb.klass.core.repository.ClassificationFamilySummary;
 import no.ssb.klass.api.controllers.ClassificationController;
 
 @Relation(collectionRelation = "classificationFamilies")
-@JsonPropertyOrder({"name", "numberOfClassifications", "links"})
+@JsonPropertyOrder({"name", "id", "numberOfClassifications", "links"})
 public class ClassificationFamilySummaryResource extends KlassResource {
     private String name;
     private int numberOfClassifications;
 
     public ClassificationFamilySummaryResource(ClassificationFamilySummary summary, Language language) {
+        super(summary.getId());
         this.name = summary.getClassificationFamilyName(language);
         this.numberOfClassifications = summary.getNumberOfClassifications();
         addLink(createSelfLink(summary.getId()));

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationResource.java
@@ -19,7 +19,7 @@ import static java.util.stream.Collectors.toList;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 @JacksonXmlRootElement(localName = "classification")
-@JsonPropertyOrder({"name", "classificationType", "lastModified", "description", "primaryLanguage","copyrighted",
+@JsonPropertyOrder({"name", "id", "classificationType", "lastModified", "description", "primaryLanguage","copyrighted",
         "includeShortName", "includeNotes", "contactPerson", "owningSection", "statisticalUnits", "versions",
         "links"})
 public class ClassificationResource extends ClassificationSummaryResource {

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationSummaryResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationSummaryResource.java
@@ -17,13 +17,14 @@ import no.ssb.klass.core.model.Language;
 import no.ssb.klass.api.controllers.ClassificationController;
 
 @Relation(collectionRelation = "classifications")
-@JsonPropertyOrder({"name", "classificationType", "lastModified", "links"})
+@JsonPropertyOrder({"name", "id", "classificationType", "lastModified", "links"})
 public class ClassificationSummaryResource extends KlassResource {
     private final String name;
     private final String classificationType;
     private final Date lastModified;
 
     protected ClassificationSummaryResource(Language language, ClassificationSeries classification) {
+        super(classification.getId());
         this.name = classification.getName(language);
         this.classificationType = classification.getClassificationType().getDisplayName(language);
         this.lastModified = classification.getLastModified();

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationVariantResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationVariantResource.java
@@ -15,7 +15,7 @@ import no.ssb.klass.core.model.Language;
 import no.ssb.klass.api.util.CustomLocalDateSerializer;
 
 @JacksonXmlRootElement(localName = "classificationVariant")
-@JsonPropertyOrder({"name", "contactPerson", "owningSection", "lastModified", "published", "validFrom", "validTo",
+@JsonPropertyOrder({"name", "id", "contactPerson", "owningSection", "lastModified", "published", "validFrom", "validTo",
         "introduction", "contactPerson", "owningSection", "correspondenceTables", "changelogs", "levels",
         "classificationItems", "links"})
 public class ClassificationVariantResource extends ClassificationVariantSummaryResource {

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationVariantSummaryResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationVariantSummaryResource.java
@@ -19,7 +19,7 @@ import no.ssb.klass.core.model.ClassificationVariant;
 import no.ssb.klass.core.model.Language;
 import no.ssb.klass.api.controllers.ClassificationController;
 
-@JsonPropertyOrder({"name", "contactPerson", "owningSection", "lastModified", "published", "links"})
+@JsonPropertyOrder({"name", "id", "contactPerson", "owningSection", "lastModified", "published", "links"})
 public class ClassificationVariantSummaryResource extends KlassResource {
     private final String name;
     private final ContactPersonResource contactPerson;
@@ -28,6 +28,7 @@ public class ClassificationVariantSummaryResource extends KlassResource {
     private final List<String> published;
 
     protected ClassificationVariantSummaryResource(ClassificationVariant variant, Language language) {
+        super(variant.getId());
         this.name = variant.getFullName(language);
         this.lastModified = variant.getLastModified();
         this.contactPerson = new ContactPersonResource(variant.getContactPerson());

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationVersionResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationVersionResource.java
@@ -16,7 +16,7 @@ import no.ssb.klass.core.model.Language;
 import no.ssb.klass.core.util.AlphaNumericalComparator;
 
 @JacksonXmlRootElement(localName = "classificationVersion")
-@JsonPropertyOrder({"name", "validFrom", "validTo", "lastModified", "published", "introduction", "contactPerson",
+@JsonPropertyOrder({"name", "id", "validFrom", "validTo", "lastModified", "published", "introduction", "contactPerson",
         "owningSection", "legalBase", "publications", "derivedFrom", "correspondenceTables", "classificationVariants",
         "changelogs", "levels", "classificationItems", "links"})
 

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationVersionSummaryResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationVersionSummaryResource.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 import static java.util.stream.Collectors.*;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
 
-@JsonPropertyOrder({"name", "validFrom", "validTo", "lastModified", "published", "links"})
+@JsonPropertyOrder({"name", "id", "validFrom", "validTo", "lastModified", "published", "links"})
 public class ClassificationVersionSummaryResource extends KlassResource {
     private final String name;
     private final LocalDate validFrom;
@@ -30,6 +30,7 @@ public class ClassificationVersionSummaryResource extends KlassResource {
     private final List<String> published;
 
     protected ClassificationVersionSummaryResource(ClassificationVersion version, Language language, Boolean includeFuture) {
+        super(version.getId());
         this.name = version.getName(language);
         this.validFrom = version.getDateRange().getFrom();
         LocalDate to = version.getDateRange().getTo();

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/CorrespondenceTableResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/CorrespondenceTableResource.java
@@ -11,7 +11,7 @@ import no.ssb.klass.core.model.CorrespondenceTable;
 import no.ssb.klass.core.model.Language;
 
 @JacksonXmlRootElement(localName = "correspondenceTable")
-@JsonPropertyOrder({"name", "contactPerson", "owningSection", "source", "sourceId", "target", "targetId", "changeTable",
+@JsonPropertyOrder({"name", "id", "contactPerson", "owningSection", "source", "sourceId", "target", "targetId", "changeTable",
         "lastModified", "published", "sourceLevel", "targetLevel", "description", "changelogs", "correspondenceMaps",
         "links"})
 public class CorrespondenceTableResource extends CorrespondenceTableSummaryResource {

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/CorrespondenceTableSummaryResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/CorrespondenceTableSummaryResource.java
@@ -20,7 +20,7 @@ import no.ssb.klass.core.model.CorrespondenceTable;
 import no.ssb.klass.core.model.Language;
 import no.ssb.klass.api.controllers.ClassificationController;
 
-@JsonPropertyOrder({"name", "contactPerson", "owningSection", "source", "sourceId", "target", "targetId", "changeTable",
+@JsonPropertyOrder({"name", "id", "contactPerson", "owningSection", "source", "sourceId", "target", "targetId", "changeTable",
         "lastModified", "published", "sourceLevel", "targetLevel", "links"})
 public class CorrespondenceTableSummaryResource extends KlassResource {
     private final String name;
@@ -37,6 +37,7 @@ public class CorrespondenceTableSummaryResource extends KlassResource {
     private final LevelResource targetLevel;
 
     protected CorrespondenceTableSummaryResource(CorrespondenceTable correspondenceTable, Language language) {
+        super(correspondenceTable.getId());
         this.name = correspondenceTable.getName(language);
         this.contactPerson = new ContactPersonResource(correspondenceTable.getContactPerson());
         this.owningSection = correspondenceTable.getContactPerson().getSection();

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/KlassResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/KlassResource.java
@@ -12,6 +12,14 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import org.springframework.lang.Nullable;
 
 public abstract class KlassResource extends PagedModel<RepresentationModel<?>> {
+
+    @JsonProperty("id")
+    private final Long id;
+
+    public KlassResource(Long id) {
+        this.id = id;
+    }
+
     protected void addLink(Link link) {
         super.add(link);
     }

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/SearchResultResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/SearchResultResource.java
@@ -14,7 +14,7 @@ import no.ssb.klass.core.service.search.SolrSearchResult;
 import no.ssb.klass.api.controllers.ClassificationController;
 
 @Relation(collectionRelation = "searchResults")
-@JsonPropertyOrder({"name", "snippet", "searchScore", "links"})
+@JsonPropertyOrder({"name", "id", "snippet", "searchScore", "links"})
 public class SearchResultResource extends KlassResource {
 
     private String name;
@@ -22,6 +22,7 @@ public class SearchResultResource extends KlassResource {
     private Double searchScore;
 
     public SearchResultResource(SolrSearchResult searchResult, List<HighlightEntry.Highlight> highlights) {
+        super(searchResult.getItemid());
         this.name = searchResult.getTitle();
         this.snippet = searchResult.getDescription();
         this.searchScore = searchResult.getScore();

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/SsbSectionResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/SsbSectionResource.java
@@ -7,6 +7,7 @@ public class SsbSectionResource extends KlassResource {
     private final String name;
 
     public SsbSectionResource(String name) {
+        super(null);
         this.name = name;
     }
 

--- a/klass-api/src/test/java/no/ssb/klass/api/applicationtest/RestApiListClassificationIntegrationTest.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/applicationtest/RestApiListClassificationIntegrationTest.java
@@ -45,7 +45,7 @@ public class RestApiListClassificationIntegrationTest extends AbstractRestApiApp
     @Test
     public void restServiceListClassificationsIncludeCodelistsJSON() {
         given().port(port).accept(ContentType.JSON).param("includeCodelists", "true").get(REQUEST)
-//                .prettyPeek()
+                .prettyPeek()
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .contentType(ContentType.JSON)
@@ -129,7 +129,7 @@ public class RestApiListClassificationIntegrationTest extends AbstractRestApiApp
     @Test
     public void restServiceListClassificationsIncludeCodelistXML() {
         given().port(port).accept(ContentType.XML).param("includeCodelists", "true").get(REQUEST)
-//                .prettyPeek()
+                .prettyPeek()
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .contentType(ContentType.XML)


### PR DESCRIPTION
The PR #153 introduced a breaking change in rendering links for XML. This is due to [Spring Hateoas doesn't actually support XML](https://github.com/spring-projects/spring-hateoas/issues/967).

This broke the code for one consumer (Oracle Statbank), but we found that they don't really need to process the link. It was just a workaround for parsing the ID. So this PR introduces an id element that can be used instead.