### PR TITLE
Connect klass-forvaltning to klass database

### DIFF
--- a/.nais/test/klass-forvaltning.yaml
+++ b/.nais/test/klass-forvaltning.yaml
@@ -17,7 +17,32 @@ spec:
     max: 1
   resources:
     requests:
-      cpu: 500m
-      memory: 1000Mi
+      cpu: 100m
+      memory: 768Mi
     limits:
-      memory: 1200Mi
+      memory: 768Mi
+  env:
+    SPRING_PROFILES_ACTIVE: frontend, postgres, small-import, skip-indexing, ad-offline, embedded-solr
+  envFrom:
+    - secret: sqluser-password-klass-forvaltning
+    - secret: google-sql-klass
+  filesFrom:
+    - mountPath: /var/run/secrets/nais.io/sqlcertificate
+      secret: sqeletor-klass-827ec8ec
+    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+      configMap: kube-root-ca.crt
+---
+apiVersion: sql.cnrm.cloud.google.com/v1beta1
+kind: SQLUser
+metadata:
+  name: klass-forvaltning
+  namespace: dapla-metadata
+spec:
+  host: ""
+  instanceRef:
+    external: klass
+  password:
+    valueFrom:
+      secretKeyRef:
+        name: sqluser-password-klass-forvaltning
+        key: NAIS_DATABASE_KLASS_KLASS_FORVALTNING_PASSWORD

--- a/klass-forvaltning/src/main/resources/application-postgres.properties
+++ b/klass-forvaltning/src/main/resources/application-postgres.properties
@@ -1,0 +1,9 @@
+# custom properties used when "postgres" Profile is used
+spring.datasource.url=jdbc:postgresql://${NAIS_DATABASE_KLASS_KLASS_HOST}:5432/${NAIS_DATABASE_KLASS_KLASS_DATABASE}?password=${NAIS_DATABASE_KLASS_KLASS_FORVALTNING_PASSWORD}&sslcert=${NAIS_DATABASE_KLASS_KLASS_SSLCERT}&sslkey=${NAIS_DATABASE_KLASS_KLASS_SSLKEY_PK8}&sslmode=${NAIS_DATABASE_KLASS_KLASS_SSLMODE}&sslrootcert=${NAIS_DATABASE_KLASS_KLASS_SSLROOTCERT}&user=${NAIS_DATABASE_KLASS_KLASS_FORVALTNING_USER}
+spring.datasource.driverclassName=org.postgresql.Driver
+spring.jpa.hibernate.ddl-auto=none
+spring.flyway.enabled=false
+spring.datasource.hikari.connection-test-query=SELECT 1
+spring.datasource.hikari.validation-timeout=3000
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
### Changes in this PR

- Add configuration for the `postgres` profile
- Set the Sping profiles to activate explicitly in the nais Application manifest
- Configure the JDBC URL to connect to the klass database, composed of environment variables mounted from secrets
- Mount the secrets which support the application connecting to the database
- Create an `SQLUser` resource which will create a user on the database
- Tune the resource allocations to those recommended

### Configuration done in addition to this PR

- Create a secret `sqluser-password-klass-forvaltning` through the nais console.
- Create a `NetworkPolicy` in the `dapla-metadata` namespace to allow egress from `klass-forvaltning` to the database.