### PR TITLE
Add health check path

### DIFF
--- a/klass-api/src/test/java/no/ssb/klass/api/migration/KlassApiMigrationClient.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/migration/KlassApiMigrationClient.java
@@ -34,7 +34,13 @@ public class KlassApiMigrationClient {
 
     public boolean isApiAvailable(String host) {
         try {
-            Response response = RestAssured.get(host + "/ping");
+            Response response;
+            if(host.equals(DATA_SSB_HOST)){
+                response = RestAssured.get(host + BASE_PATH + "/ping");
+            }
+            else{
+                response = RestAssured.get(host + "/ping");
+            }
             return response.getStatusCode() == 200;
         } catch (Exception e) {
             return false;

--- a/klass-api/src/test/java/no/ssb/klass/api/migration/MigrationTestConstants.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/migration/MigrationTestConstants.java
@@ -7,6 +7,7 @@ import java.util.List;
 public final class MigrationTestConstants {
 
     // paths
+    public static final String DATA_SSB_HOST = "https://data.ssb.no";
     public static final String BASE_PATH = "/api/klass";
     public static final String CLASSIFICATIONS_PATH = "/classifications";
     public static final String CHANGES = "changes";


### PR DESCRIPTION
There is a health check before running migration tests at both source and target host.
When source host is `https://data.ssb.no` the path requires `/api/klass` before `/ping`
