### PR TITLE
Improve tests for classification families repository

### DIFF
--- a/klass-shared/src/test/java/no/ssb/klass/core/repository/ClassificationFamilyRepositoryTest.java
+++ b/klass-shared/src/test/java/no/ssb/klass/core/repository/ClassificationFamilyRepositoryTest.java
@@ -185,6 +185,26 @@ public class ClassificationFamilyRepositoryTest {
     }
 
     @Test
+    public void findClassificationFamilySummariesOneClassificationIsCopyrightedNotPublic() {
+        // This test is for demonstrating why we should test method 'findPublicClassificationFamilySummaries' which
+        // is used in klass-api and not 'findClassificationFamilySummaries'
+
+        // given
+        ClassificationFamily family = createClassificationFamilyOneClassificationIsCopyrighted();
+        subject.save(family);
+
+        assertThat(family.getClassificationSeries().size()).isEqualTo(2);
+
+        // when
+        List<ClassificationFamilySummary> result = subject.findClassificationFamilySummaries(allSections,
+                allClassificationTypes);
+
+        // then
+        assertEquals(1, result.size());
+        assertEquals(2, result.get(0).getNumberOfClassifications());
+    }
+
+    @Test
     public void findClassificationFamilySummariesOneClassificationIsDeleted() {
         // given
         ClassificationFamily family = createClassificationFamilyOneClassificationIsDeleted();


### PR DESCRIPTION
All tests for `ClassificationFamilyRepository` used method which is only used in `ApiDocumentation`.
This method does not filter number of classifications.

- Use `findPublicClassificationFamilySummaries()`in tests
- Add tests/test data for all filters:
   - Classification copyrighted
   - Classification deleted
   - Version deleted
   - Version not published (in any languages)

