### PR TITLE
Klass-forvaltning: limit db connections

### DIFF
--- a/.github/workflows/klass-forvaltning-build-and-deploy.yaml
+++ b/.github/workflows/klass-forvaltning-build-and-deploy.yaml
@@ -3,9 +3,10 @@ name: Klass-forvaltning build and deploy
 on:
   release:
     types: [ published ]
-  push:
-    branches:
-      - nais-migration
+  #  push:
+  #    branches:
+  #      - nais-migration
+  pull_request:
     paths:
       - "klass-forvaltning/**"
       - ".nais/**/klass-forvaltning.yaml"

--- a/.github/workflows/klass-forvaltning-build-and-deploy.yaml
+++ b/.github/workflows/klass-forvaltning-build-and-deploy.yaml
@@ -3,10 +3,9 @@ name: Klass-forvaltning build and deploy
 on:
   release:
     types: [ published ]
-  #  push:
-  #    branches:
-  #      - nais-migration
-  pull_request:
+  push:
+    branches:
+      - nais-migration
     paths:
       - "klass-forvaltning/**"
       - ".nais/**/klass-forvaltning.yaml"

--- a/klass-forvaltning/src/main/resources/application-postgres-local.properties
+++ b/klass-forvaltning/src/main/resources/application-postgres-local.properties
@@ -2,6 +2,10 @@
 spring.datasource.url=jdbc:postgresql://${POSTGRES_INSTANCE}:5432/klass
 spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}
+# Avoid exhausting the connection pool
+spring.datasource.tomcat.max-active=5
+spring.datasource.tomcat.max-idle=5
+spring.datasource.tomcat.remove-abandoned=true
 flyway.enabled=false
 spring.jpa.hibernate.ddl-auto=none
 spring.datasource.hikari.connection-test-query=SELECT 1

--- a/klass-forvaltning/src/main/resources/application-postgres.properties
+++ b/klass-forvaltning/src/main/resources/application-postgres.properties
@@ -1,6 +1,9 @@
 # custom properties used when "postgres" Profile is used
 spring.datasource.url=${NAIS_DATABASE_KLASS_KLASS_JDBC_URL}
-spring.datasource.driver-class-name=org.postgresql.Driver
+# Avoid exhausting the connection pool
+spring.datasource.tomcat.max-active=5
+spring.datasource.tomcat.max-idle=5
+spring.datasource.tomcat.remove-abandoned=true
 flyway.enabled=false
 spring.jpa.hibernate.ddl-auto=none
 spring.datasource.hikari.connection-test-query=SELECT 1

--- a/klass-shared/docker-compose.yaml
+++ b/klass-shared/docker-compose.yaml
@@ -14,7 +14,6 @@ services:
   postgresql:
     image: postgres:17.4
     profiles: [ migration-testing, migrate-data, frontend, api, search ]
-    container_name: klass_postgres
     ports:
       - "5432:5432"
     volumes:
@@ -24,10 +23,11 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_USER: "klass"
       POSTGRES_DATABASE: "klass"
-      POSTGRES_LOCAL_FILEPATH: ${POSTGRES_LOCAL_FILEPATH}
   klass-api:
-    image: target-postgres-image:latest
-    command: [ "java", "-jar", "app.war", "--spring.profiles.active=api, postgres-local, skip-indexing, embedded-solr" ]
+    build:
+      context: ../klass-api
+      dockerfile: ../klass-api/Dockerfile
+    command: [ "java", "-jar", "app.war" ]
     container_name: klass-api
     profiles: [ migration-testing, api ]
     depends_on:
@@ -43,7 +43,7 @@ services:
       SPRING_PROFILES_ACTIVE: api, postgres-local, skip-indexing, embedded-solr
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_USER: "klass"
-      POSTGRES_INSTANCE: ${POSTGRES_INSTANCE}
+      POSTGRES_INSTANCE: postgresql
   klass-api-mariadb:
     image: source-mariadb-image:latest
     command: [ "java", "-jar", "app.war", "--spring.profiles.active=api, mariadb-local, skip-indexing, embedded-solr" ]
@@ -65,7 +65,7 @@ services:
       MARIADB_LOCAL_FILEPATH: ${MARIADB_LOCAL_FILEPATH}
       MARIADB_DATABASE: "klass"
       SPRING_PROFILES_ACTIVE: "mariadb-local"
-      MARIADB_INSTANCE: ${MARIADB_INSTANCE}
+      MARIADB_INSTANCE: mariadb
   klass-api-search:
     image: target-postgres-image:latest
     container_name: klass-api
@@ -87,7 +87,7 @@ services:
       SPRING_DATA_SOLR_HOST: http://solr:8983/solr
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_USER: "klass"
-      POSTGRES_INSTANCE: ${POSTGRES_INSTANCE}
+      POSTGRES_INSTANCE: postgresql
   klass-forvaltning:
     build:
       context: ../klass-forvaltning
@@ -98,15 +98,16 @@ services:
       - "8081:8081"
     depends_on:
       - postgresql
-    command: [ "java", "-XshowSettings:vm", "-Xms512m", "-Xmx2g", "-jar", "app.war", "--spring.profiles.active=frontend, postgres-local, ad-offline, small-import, skip-indexing, embedded-solr" ]
+    command: [ "java", "-XshowSettings:vm", "-Xms512m", "-Xmx2g", "-jar", "app.war" ]
     deploy:
       resources:
         limits:
           memory: 3G
     environment:
+      SPRING_PROFILES_ACTIVE: frontend, hardcoded-user, postgres-local, ad-offline, small-import, skip-indexing, embedded-solr
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_USER: "klass"
-      POSTGRES_INSTANCE: ${POSTGRES_INSTANCE}
+      POSTGRES_USER: klass
+      POSTGRES_INSTANCE: postgresql
   solr:
     build:
       context: .


### PR DESCRIPTION
Our database in test has a maximum of 25 connections and these live for at least 10 minutes. By default klass-forvaltning would attempt to start up to 100 connections. The connection pool was constantly full and this was preventing new instances from starting. This PR limits how many connections are established.

![Screenshot 2025-06-26 at 15 08 28](https://github.com/user-attachments/assets/f7f981fd-60ec-4cb4-a893-1ede327c994e)
