### PR TITLE
Exclude solr from the health check

### DIFF
--- a/.github/workflows/klass-forvaltning-build-and-deploy.yaml
+++ b/.github/workflows/klass-forvaltning-build-and-deploy.yaml
@@ -3,9 +3,10 @@ name: Klass-forvaltning build and deploy
 on:
   release:
     types: [ published ]
-  push:
-    branches:
-      - nais-migration
+  #  push:
+  #    branches:
+  #      - nais-migration
+  pull_request:
     paths:
       - "klass-forvaltning/**"
       - ".nais/**/klass-forvaltning.yaml"

--- a/.github/workflows/klass-forvaltning-build-and-deploy.yaml
+++ b/.github/workflows/klass-forvaltning-build-and-deploy.yaml
@@ -3,10 +3,9 @@ name: Klass-forvaltning build and deploy
 on:
   release:
     types: [ published ]
-  #  push:
-  #    branches:
-  #      - nais-migration
-  pull_request:
+  push:
+    branches:
+      - nais-migration
     paths:
       - "klass-forvaltning/**"
       - ".nais/**/klass-forvaltning.yaml"

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@ target
 .settings/
 .designer/
 
+
 **/.env
-**/postgresql/data/
+pgdata/
 
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,14 @@ run-klass-forvaltning-local-postgres:
 	popd; \
 	${sdk} env clear
 
+.PHONY: run-klass-forvaltning-local-postgres-search
+run-klass-forvaltning-local-postgres-search:
+	pushd klass-forvaltning && \
+	${sdk} env && \
+	mvn spring-boot\:run -Dspring.profiles.active=postgres-local,hardcoded-user,frontend,skip-indexing,small-import,ad-offline,remote-solr -Dklass.env.search.solr.url=http://localhost:8983/solr/; \
+	popd; \
+	${sdk} env clear
+
 
 .PHONY: run-klass-forvaltning-local-mariadb
 # Requires that a MariaDB instance is already running with a database called klass and a user called klass.

--- a/klass-forvaltning/src/main/resources/application.properties
+++ b/klass-forvaltning/src/main/resources/application.properties
@@ -33,6 +33,7 @@ endpoints.enabled=true
 endpoints.sensitive=false
 # Not currently configured
 management.health.mail.enabled=false
+management.health.solr.enabled=false
 # Environment properties, prefixed with klass.env. These properties may change between different environments
 klass.env.mariadb.instance=${KLASS_ENV_MARIADB_INSTANCE:Undefined 127.0.0.1}
 # Give password as environment variable
@@ -50,6 +51,7 @@ klass.search.maxDescriptionLength=300
 # Security properties
 # Only for test/development user. Valid values are STANDARD, ADMIN.
 klass.security.hardcoded.user.role=ADMIN
+klass.security.roles.admin.users=
 klass.security.oauth2.jwt.jwks.uri=https://auth.test.ssb.no/realms/ssb/protocol/openid-connect/certs
 klass.security.oauth2.jwt.issuer=https://auth.test.ssb.no/realms/ssb
 klass.security.oauth2.protected.paths=/klassui

--- a/klass-shared/docker-compose.yaml
+++ b/klass-shared/docker-compose.yaml
@@ -2,7 +2,6 @@ services:
   mariadb:
     image: mariadb:11.7
     profiles: [ migration-testing, migrate-data ]
-    container_name: klass_mariadb
     ports:
       - "3306:3306"
     environment:
@@ -28,7 +27,6 @@ services:
       context: ../klass-api
       dockerfile: ../klass-api/Dockerfile
     command: [ "java", "-jar", "app.war" ]
-    container_name: klass-api
     profiles: [ migration-testing, api ]
     depends_on:
       - postgresql
@@ -47,7 +45,6 @@ services:
   klass-api-mariadb:
     image: source-mariadb-image:latest
     command: [ "java", "-jar", "app.war", "--spring.profiles.active=api, mariadb-local, skip-indexing, embedded-solr" ]
-    container_name: klass-api-mariadb
     profiles: [ migration-testing ]
     depends_on:
       - mariadb
@@ -67,8 +64,9 @@ services:
       SPRING_PROFILES_ACTIVE: "mariadb-local"
       MARIADB_INSTANCE: mariadb
   klass-api-search:
-    image: target-postgres-image:latest
-    container_name: klass-api
+    build:
+      context: ../klass-api
+      dockerfile: ../klass-api/Dockerfile
     command: [ "java", "-Xms2g", "-Xmx4g", "-jar", "app.war" ]
     profiles: [ search ]
     depends_on:
@@ -94,7 +92,6 @@ services:
     build:
       context: ../klass-forvaltning
       dockerfile: ../klass-forvaltning/Dockerfile
-    container_name: klass-forvaltning
     profiles: [ frontend ]
     ports:
       - "8081:8081"
@@ -114,7 +111,6 @@ services:
     build:
       context: ../klass-forvaltning
       dockerfile: ../klass-forvaltning/Dockerfile
-    container_name: klass-forvaltning
     profiles: [ search ]
     ports:
       - "8081:8081"
@@ -134,9 +130,10 @@ services:
       KLASS_ENV_SEARCH_SOLR_URL: http://solr:8983/solr/
       KLASS_ENV_SEARCH_SOLR_CORE: Klass
   solr:
-    image: klass-shared-solr:5.5.2
-    container_name: solr
-    profiles: [search]
+    build:
+      context: ../klass-solr
+      dockerfile: ../klass-solr/Dockerfile
+    profiles: [ search ]
     ports:
       - "8983:8983"
     mem_limit: 4g


### PR DESCRIPTION
The health check requested an invalid URL and constantly failed even though search is working correctly. We exclude this from the health check.

Also updates docker-compose and Makefile to support local running.