### PR TITLE
Delete linked maps when deleting correspondence table

### DIFF
--- a/klass-shared/src/main/java/no/ssb/klass/core/service/ClassificationServiceImpl.java
+++ b/klass-shared/src/main/java/no/ssb/klass/core/service/ClassificationServiceImpl.java
@@ -451,6 +451,10 @@ public class ClassificationServiceImpl implements ClassificationService {
             throws KlassMessageException {
         checkAllowedToDelete(user, correspondenceTable);
         correspondenceTable.setDeleted();
+        // Delete all the correspondence maps to avoid future constraint violations
+        correspondenceTable.getCorrespondenceMaps().forEach(map -> correspondenceMapRepository.delete(map.getId()));
+        // This just updates the object in memory, has no effect on persistence
+        correspondenceTable.removeAllCorrespondenceMaps();
         saveNotIndexCorrespondenceTable(correspondenceTable);
     }
 

--- a/klass-shared/src/test/java/no/ssb/klass/core/service/ClassificationServiceImplTest.java
+++ b/klass-shared/src/test/java/no/ssb/klass/core/service/ClassificationServiceImplTest.java
@@ -698,6 +698,27 @@ public class ClassificationServiceImplTest {
         assertEquals(1, result.size());
     }
 
+    @Test
+    public void deleteCorrespondenceTable() throws KlassMessageException {
+        // given
+        ClassificationVersion source = createClassificationVersion();
+        CorrespondenceTable correspondenceTable = TestUtil.createCorrespondenceTable(source,
+                createClassificationVersion());
+
+        correspondenceTable.addCorrespondenceMap(new CorrespondenceMap(TestUtil.createClassificationItem("code1", "Code 1"), TestUtil.createClassificationItem("code2", "Code 2")));
+        correspondenceTable.addCorrespondenceMap(new CorrespondenceMap(TestUtil.createClassificationItem("code3", "Code 3"), TestUtil.createClassificationItem("code4", "Code 4")));
+        correspondenceTable.unpublish(Language.getDefault());
+        when(correspondenceTableRepositoryMock.save(correspondenceTable)).thenReturn(correspondenceTable);
+
+        // when
+        subject.deleteNotIndexCorrespondenceTable(TestUtil.createUser(), correspondenceTable);
+
+        // then
+        assertTrue(correspondenceTable.isDeleted());
+        verify(correspondenceMapRepositoryMock, times(2)).delete(anyLong());
+        assertEquals(0, correspondenceTable.getCorrespondenceMaps().size());
+    }
+
     private ClassificationVersion createClassificationVersion() {
         ClassificationVersion version = TestUtil.createClassificationVersion(TestUtil.anyDateRange());
         ClassificationSeries classification = TestUtil.createClassification("name");


### PR DESCRIPTION
Correspondence maps are left orphaned in the database. This can cause foreign key constraint violations when deleting items they reference. This is preventing users from updating their data.

The solution is to explicitly hard delete correspondence maps when soft deleting a correspondence table