### PR TITLE
Add ingress to allow Wonderwall redirect

### DIFF
--- a/.nais/test/klass-forvaltning.yaml
+++ b/.nais/test/klass-forvaltning.yaml
@@ -10,6 +10,7 @@ spec:
   port: 8081
   ingresses:
     - https://klass-forvaltning.intern.test.ssb.no
+    - https://i.test.ssb.no/klass/admin
   accessPolicy:
     outbound:
       external:


### PR DESCRIPTION
This is a suggestion from the nais team to allow Wonderwall to redirect to the external URL, not just the normal nais ingress.