### PR TITLE
Skip build when only manifest file is changed

### DIFF
--- a/.github/workflows/klass-api-build-and-deploy.yaml
+++ b/.github/workflows/klass-api-build-and-deploy.yaml
@@ -24,6 +24,7 @@ jobs:
       image: ${{ steps.docker-build-push.outputs.image }}
       telemetry: ${{ steps.docker-build-push.outputs.telemetry }}
       prod-config-only: ${{ steps.prod-config-changed.outputs.changed == 'only-inputs' }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
- Split the deploy into 2 parts one for test and one for prod. This makes it easier to handle deploys for when only the configs are changed. 
- Added a what-changed step for only the prod config. This allows us to check if only the prod config file has been changed and will trigger a deploy to prod in that case.

So the logic for when the different environments are deployed to is as following.
- prod when there is a new release 
- prod if only the prod config is changed (skips build)
- test when there is not a new release
- test if only the test config is changed (skips build)
