### PR TITLE
Enable access logging

### DIFF
--- a/.github/workflows/klass-api-build-and-deploy.yaml
+++ b/.github/workflows/klass-api-build-and-deploy.yaml
@@ -4,8 +4,8 @@ on:
   release:
     types: [ published ]
   push:
-    branches:
-      - nais-migration
+    #    branches:
+    #      - nais-migration
     paths:
       - "klass-api/**"
       - "klass-shared/**"

--- a/.github/workflows/klass-api-build-and-deploy.yaml
+++ b/.github/workflows/klass-api-build-and-deploy.yaml
@@ -4,8 +4,8 @@ on:
   release:
     types: [ published ]
   push:
-    #    branches:
-    #      - nais-migration
+    branches:
+      - nais-migration
     paths:
       - "klass-api/**"
       - "klass-shared/**"

--- a/.nais/test/klass-api.yaml
+++ b/.nais/test/klass-api.yaml
@@ -56,3 +56,4 @@ spec:
     path: /actuator/health/liveness
     port: 8090
     initialDelay: 60
+    timeout: 180

--- a/klass-api/src/main/resources/application.properties
+++ b/klass-api/src/main/resources/application.properties
@@ -36,7 +36,7 @@ spring.profiles.active=api, postgres-local, skip-indexing, embedded-solr
 server.port=8080
 management.server.port=8090
 management.endpoints.web.base-path=/actuator
-management.endpoints.web.exposure.include=health,info,prometheus,trace
+management.endpoints.web.exposure.include=*
 management.endpoint.httptrace.enabled=true
 management.endpoint.prometheus.enabled=true
 # solr Properties

--- a/klass-api/src/main/resources/application.properties
+++ b/klass-api/src/main/resources/application.properties
@@ -37,7 +37,6 @@ server.port=8080
 management.server.port=8090
 management.endpoints.web.base-path=/actuator
 management.endpoints.web.exposure.include=*
-management.endpoint.httptrace.enabled=true
 management.endpoint.prometheus.enabled=true
 # solr Properties
 klass.env.search.solr.url=http://localhost:8983/solr
@@ -46,17 +45,41 @@ klass.env.search.solr.core=Klass
 klass.search.resultsPerPage=10
 klass.search.maxDescriptionLength=300
 # Logging properties
-klass.env.logging.path=.
-logging.file.name=${klass.env.logging.path}/klass.log
 logging.level.no.ssb.klass=DEBUG
+logging.file.path=/dev
+logging.file.name=stdout
+server.tomcat.accesslog.enabled=true
+server.tomcat.accesslog.directory=/dev
+server.tomcat.accesslog.prefix=stdout
+server.tomcat.accesslog.pattern={\
+  "@timestamp":"%{yyyy-MM-dd'T'HH:mm:ss.SSSXXX}t",\
+  "context":"klass-api",\
+  "logger_name":"tomcat.access",\
+  "level":"INFO",\
+  "httpRequest":{\
+    "method":"%m",\
+    "uri":"%U",\
+    "query":"%q",\
+    "status":"%s",\
+    "headers":{\
+        "userAgent":"%{User-Agent}i",\
+        "xForwardedProto":"%{X-Forwarded-Proto}i",\
+        "xForwardedFor":"%{X-Forwarded-For}i",\
+        "xForwardedHost":"%{X-Forwarded-Host}i,\
+        "xSsbEnv":"%{X-Ssb-Env}i"\
+        },\
+    "bytes":"%b",\
+    "remoteAddr":"%a"\
+    },\
+  "thread":"%I"\
+  }
+server.tomcat.accesslog.suffix=
+server.tomcat.accesslog.file-date-format=
 # JSP config (for monitor page)
 spring.mvc.view.prefix=/WEB-INF/jsp/
 spring.mvc.view.suffix=.jsp
 # Mail properties
 klass.env.client.klass-mail.url=http://localhost:8082
-spring.mail.port=25
-spring.mail.host=mail.example.com
-spring.mail.properties.mail.from=noreply@example.com
 # hibernate config
 spring.jpa.properties.hibernate.session_factory.interceptor=no.ssb.klass.core.util.BaseEntityInterceptor
 #context path for API docs

--- a/klass-api/src/main/resources/application.properties
+++ b/klass-api/src/main/resources/application.properties
@@ -36,7 +36,8 @@ spring.profiles.active=api, postgres-local, skip-indexing, embedded-solr
 server.port=8080
 management.server.port=8090
 management.endpoints.web.base-path=/actuator
-management.endpoints.web.exposure.include=health,info,prometheus
+management.endpoints.web.exposure.include=health,info,prometheus,trace
+management.endpoint.httptrace.enabled=true
 management.endpoint.prometheus.enabled=true
 # solr Properties
 klass.env.search.solr.url=http://localhost:8983/solr


### PR DESCRIPTION
- Extend the timeout for the startup probe to avoid restarts
- Enable all management endpoints since these are very useful for debugging
- Configure tomcat access logging
  - Same format as the other logs
  - No possiblility to include _all_ headers, we need to add them by name as required
  - An error is produced on startup due to the server hosting the management endpoints changing the log file name. I haven'r found a fix for this unfortunately.
