### PR TITLE
Set the Jackson timezone property

### DIFF
--- a/klass-api/src/main/resources/application.properties
+++ b/klass-api/src/main/resources/application.properties
@@ -94,6 +94,9 @@ klass.env.api.path=/api/klass
 # Spring Boot 2.1 disabled bean overriding by default as a defensive approach.
 # But we need to override some beans in our tests, so we need to enable it.
 spring.main.allow-bean-definition-overriding=true
+# Previous deployments of this app have used this timezone due to server
+# configuration, so we maintain this to avoid time jumps in the API
+spring.jackson.time-zone=UTC
 # Spring MVC 5.3 disabled suffix pattern matching by default as a defensive approach.
 # But we need to re-enable this since buttons from ssb.no/klass still uses it
 spring.mvc.pathmatch.use-registered-suffix-pattern=true


### PR DESCRIPTION
From local testing, this produced the same value in the response as we receive from the on-prem server. This is important to avoid unintentional API changes for consumers.