### PR TITLE
Klass API: Increase CPU request

### DIFF
--- a/.nais/test/klass-api.yaml
+++ b/.nais/test/klass-api.yaml
@@ -15,7 +15,7 @@ spec:
     max: 1
   resources:
     requests:
-      cpu: 100m
+      cpu: 200m
       memory: 800Mi
     limits:
       memory: 832Mi


### PR DESCRIPTION
After running a performance test it could be observed that Klass used up to 200mCPU so we increase the request to match.

<img width="504" height="323" alt="Screenshot 2025-08-27 at 11 13 44" src="https://github.com/user-attachments/assets/513579f0-1bf0-4fb2-8ba3-38d4b19e9095" />
