### PR TITLE
Klass-api: set resources and scaling in prod

### DIFF
--- a/.nais/prod/klass-api.yaml
+++ b/.nais/prod/klass-api.yaml
@@ -8,19 +8,20 @@ metadata:
     team: dapla-metadata
 spec:
   port: 8080
-
   ingresses:
-    - https://klass.intern.ssb.no
-
+    - https://klass.intern.ssb.no/api/klass
   replicas:
-    min: 1
-    max: 1
+    min: 2
+    max: 6
+    scalingStrategy:
+      cpu:
+        thresholdPercentage: 90
   resources:
     requests:
-      cpu: 400m
-      memory: 1024Mi
+      cpu: 200m
+      memory: 800Mi
     limits:
-      memory: 2048Mi
+      memory: 832Mi
   gcp:
     sqlInstances:
       - type: POSTGRES_17
@@ -43,7 +44,7 @@ spec:
 
   prometheus:
     enabled: true
-    path: /prometheus
+    path: /actuator/prometheus
     port: "8090"
 
   liveness:

--- a/.nais/test/klass-api.yaml
+++ b/.nais/test/klass-api.yaml
@@ -48,10 +48,12 @@ spec:
     path: /actuator/health/liveness
     port: 8090
     initialDelay: 60
+    timeout: 180
   readiness:
     path: /actuator/health/readiness
     port: 8090
     initialDelay: 60
+    timeout: 180
   startup:
     path: /actuator/health/liveness
     port: 8090


### PR DESCRIPTION
- Update resources and other configuration values to match the test environment manifest
- Configure auto-scaling to have at least 2 replicas and up to 6
- Configure the CPU threshold to avoid unnecessary scaling as much as possible