### PR TITLE
Display full section name ssb sections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,27 @@ build-klass-forvaltning:
 	popd; \
 	${sdk} env clear
 
+.PHONY: build-clean-klass-forvaltning
+build-clean-klass-forvaltning:
+	pushd klass-forvaltning && \
+	${sdk} env && \
+	mvn clean install; \
+ 	popd; \
+	${sdk} env clear
+
 .PHONY: build-klass-api
 build-klass-api:
 	pushd klass-api && \
 	${sdk} env && \
 	mvn install; \
+ 	popd; \
+	${sdk} env clear
+
+.PHONY: build-clean-klass-api
+build-clean-klass-api:
+	pushd klass-api && \
+	${sdk} env && \
+	mvn clean install; \
  	popd; \
 	${sdk} env clear
 

--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,28 @@ clean-klass-forvaltning-volumes:
 start-klass-api-docker:
 	docker compose $(COMPOSE_FILE) --profile api up --build -d
 
+.PHONY: check-klass-api-docker
+check-klass-api-docker:
+	docker compose $(COMPOSE_FILE) --profile api ps
+
+.PHONY: rebuild-klass-api-docker
+rebuild-klass-api-docker:
+	docker compose $(COMPOSE_FILE) --profile api build --no-cache klass-api
+
+.PHONY: rebuild-klass-forvaltning-docker
+rebuild-klass-forvaltning-docker:
+	docker compose $(COMPOSE_FILE) --profile frontend build --no-cache klass-forvaltning
+
+.PHONY: restart-klass-api-docker
+restart-klass-api-docker:
+	docker compose $(COMPOSE_FILE) --profile api restart klass-api
+
+# Log only klass-api
 .PHONY: logs-klass-api
 logs-klass-api:
-	docker compose $(COMPOSE_FILE) --profile api logs -f
+	docker compose $(COMPOSE_FILE) --profile api logs --tail=100 -f klass-api
 
 .PHONY: stop-klass-api-docker
 stop-klass-api-docker:
 	docker compose $(COMPOSE_FILE) --profile api down
+

--- a/klass-forvaltning/src/main/resources/application.properties
+++ b/klass-forvaltning/src/main/resources/application.properties
@@ -71,3 +71,5 @@ spring.jpa.properties.hibernate.session_factory.interceptor=no.ssb.klass.core.ut
 spring.jackson.serialization.indent_output=true
 # Prevent runtime warnings about missing jars
 server.tomcat.additional-tld-skip-patterns=*.jar
+# Flyway will be removed from this module, until then make sure Flyway never run
+flyway.enabled=false

--- a/klass-shared/src/main/java/no/ssb/klass/core/service/ClassificationServiceHelper.java
+++ b/klass-shared/src/main/java/no/ssb/klass/core/service/ClassificationServiceHelper.java
@@ -13,6 +13,7 @@ import no.ssb.klass.core.service.dto.CodeDto;
 import no.ssb.klass.core.service.dto.CorrespondenceDto;
 import no.ssb.klass.core.util.DateRange;
 import no.ssb.klass.core.util.KlassResourceNotFoundException;
+import no.ssb.klass.core.util.Translatable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -161,6 +162,12 @@ final class ClassificationServiceHelper {
     private static List<CodeDto> toCodes(List<ClassificationItem> classificationItems, Level level, DateRange dateRange,
                                          Language language) {
         return classificationItems.stream().map(item -> new CodeDto(level, item, dateRange, language)).collect(toList());
+    }
+
+    static final Translatable SSB_SECTION_NAME = new Translatable("Standard for seksjonsinndeling", "Standard for seksjonsinndeling", "Classification of organisational units");
+
+    static String formatSectionLabel(ClassificationItem item, Language language) {
+        return item.getCode() + " - " + item.getOfficialName(language);
     }
 
 }

--- a/klass-shared/src/main/java/no/ssb/klass/core/service/ClassificationServiceImpl.java
+++ b/klass-shared/src/main/java/no/ssb/klass/core/service/ClassificationServiceImpl.java
@@ -25,13 +25,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static no.ssb.klass.core.service.ClassificationServiceHelper.SSB_SECTION_NAME;
 
 @Service
 @Transactional()
 public class ClassificationServiceImpl implements ClassificationService {
 
-
-    private static final Logger log = LoggerFactory.getLogger(ClassificationServiceImpl.class);
     private final ClassificationFamilyRepository classificationFamilyRepository;
     private final ClassificationSeriesRepository classificationRepository;
     private final ClassificationVersionRepository classificationVersionRepository;
@@ -392,13 +391,13 @@ public class ClassificationServiceImpl implements ClassificationService {
     @Override
     @Transactional(readOnly = true)
     public Set<String> findAllResponsibleSections() {
-        return classificationRepository.findAllResponsibleSections();
+        return resolveResponsibleSectionNames(classificationRepository.findAllResponsibleSections());
     }
 
     @Override
     @Transactional(readOnly = true)
     public Set<String> findResponsibleSectionsWithPublishedVersions() {
-        return classificationRepository.findResponsibleSectionsWithPublishedVersions();
+        return resolveResponsibleSectionNames(classificationRepository.findResponsibleSectionsWithPublishedVersions());
     }
 
     @Override
@@ -616,6 +615,25 @@ public class ClassificationServiceImpl implements ClassificationService {
 
         }
         return matchingCorrespondenceTables;
+    }
+
+    /**
+     * Maps section codes to display names in the form "<code> - <officialName>".
+     *
+     * @param responsibleSectionCodes section codes to resolve
+     * @return formatted section names
+     */
+    private Set<String> resolveResponsibleSectionNames(Set<String> responsibleSectionCodes) {
+        // Use language NB until logic for selecting language for path /ssbsections is implemented
+        Language language = Language.NB;
+        return findOneClassificationSeriesWithName(SSB_SECTION_NAME.getString(language), language)
+                .map(ClassificationSeries::getNewestVersion)
+                .map(ClassificationVersion::getAllClassificationItems)
+                .stream()
+                .flatMap(Collection::stream)
+                .filter(item -> responsibleSectionCodes.contains(item.getCode()))
+                .map(item -> ClassificationServiceHelper.formatSectionLabel(item, language))
+                .collect(toSet());
     }
 
 }

--- a/klass-shared/src/main/java/no/ssb/klass/core/service/ClassificationServiceImpl.java
+++ b/klass-shared/src/main/java/no/ssb/klass/core/service/ClassificationServiceImpl.java
@@ -11,6 +11,8 @@ import no.ssb.klass.core.util.KlassResourceNotFoundException;
 import no.ssb.klass.core.util.TimeUtil;
 import no.ssb.klass.core.util.Translatable;
 import org.hibernate.Hibernate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -28,6 +30,8 @@ import static java.util.stream.Collectors.toSet;
 @Transactional()
 public class ClassificationServiceImpl implements ClassificationService {
 
+
+    private static final Logger log = LoggerFactory.getLogger(ClassificationServiceImpl.class);
     private final ClassificationFamilyRepository classificationFamilyRepository;
     private final ClassificationSeriesRepository classificationRepository;
     private final ClassificationVersionRepository classificationVersionRepository;

--- a/klass-shared/src/test/java/no/ssb/klass/core/service/ClassificationServiceImplTest.java
+++ b/klass-shared/src/test/java/no/ssb/klass/core/service/ClassificationServiceImplTest.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 import java.time.LocalDate;
 import java.util.*;
 
+import static no.ssb.klass.core.service.ClassificationServiceHelper.SSB_SECTION_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
@@ -670,6 +671,35 @@ public class ClassificationServiceImplTest {
 
         // then
         assertEquals(1, result.size());
+    }
+
+    @Test
+    void findAllResponsibleSections() {
+        String sectionMicroDataName = "Seksjon for mikrodata";
+        String sectionMicroDataCode = "300";
+        String sectionPropertyName= "Seksjon for eiendoms-, areal- og primærnæringsstatistikk";
+        String sectionPropertyCode = "426";
+
+        ClassificationItem item1 = TestUtil.createClassificationItem(sectionMicroDataCode, sectionMicroDataName);
+        ClassificationItem item2 = TestUtil.createClassificationItem(sectionPropertyCode, sectionPropertyName);
+        ClassificationSeries series = TestUtil.createClassification(SSB_SECTION_NAME.getString(Language.NB));
+        DateRange dateRange = DateRange.create("2025-01-01", "2025-08-01");
+        ClassificationVersion version = TestUtil.createClassificationVersion(dateRange);
+        version.addNextLevel();
+        series.addClassificationVersion(version);
+        version.addClassificationItem(item1, 1, null);
+        version.addClassificationItem(item2, 1, null);
+
+        Set<String> codes = Set.of(sectionMicroDataCode, sectionPropertyCode, "");
+        when(classificationSeriesRepositoryMock.findAllResponsibleSections()).thenReturn(codes);
+
+        when(classificationSeriesRepositoryMock.findByNameNoIgnoreCase(SSB_SECTION_NAME.getString(Language.NB)))
+                .thenReturn(series);
+
+        Set<String> result = subject.findAllResponsibleSections();
+
+        assertThat(result).containsExactlyInAnyOrder(sectionPropertyCode + " - " + sectionPropertyName, sectionMicroDataCode + " - " +  sectionMicroDataName);
+        assertThat(result).doesNotContain("");
     }
 
     private ClassificationVersion createClassificationVersion() {


### PR DESCRIPTION
Ref: https://statistics-norway.atlassian.net/browse/DPMETA-954

This is the first PR of three handling displaying section following the change to column `user.section ` where only section code is persisted.

**Displaying full section name at path `/ssbsections`**.
- Fetches the classification for SSB sections by name and compares codes to the newest version.
- Method `findResponsibleSectionsWithPublishedVersions` in `klass-shared`is used in `klass-api`, `findAllResponsibleSections` is used in `klass-forvaltning` and must be implemented in version 2x.
- Language is currently fixed to Norwegian Bokmål (NB). The logic is built so that it can be extended in the future to support multiple languages.

Also:
- add make commands
- disable Flyway klass forvaltning for all profiles


