### PR TITLE
Klass-forvaltning: One instance

### DIFF
--- a/.nais/prod/klass-forvaltning.yaml
+++ b/.nais/prod/klass-forvaltning.yaml
@@ -23,8 +23,8 @@ spec:
       excludePaths:
         - /klass/admin/schemas/version.xsd
   replicas:
-    min: 2
-    max: 2
+    min: 1
+    max: 1
   resources:
     requests:
       cpu: 400m
@@ -46,6 +46,8 @@ spec:
       value: klass.intern.ssb.no
     - name: KLASS_ENV_CLIENT_KLASS_MAIL_URL
       value: http://klass-mail
+    - name: LOGGING_LEVEL_NO_SSB_KLASS
+      value: INFO
   envFrom:
     - secret: google-sql-klass
     - secret: klass-forvaltning-application-properties


### PR DESCRIPTION
Due to the authentication in klass-forvaltning being stateful, we need to run only a single instance, otherwise the user's session expires often.