### PR TITLE
Edit integrity tests and improve docker container memory

### DIFF
--- a/klass-api/src/test/java/no/ssb/klass/api/migration/MigrationTestUtils.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/migration/MigrationTestUtils.java
@@ -296,15 +296,15 @@ public class MigrationTestUtils {
                 .isEqualTo(targetList.size());
 
         for (int i = 0; i < sourceList.size(); i++){
-            String sourceName = sourceList.get(i).get("name").toString();
-            String targetName = targetList.get(i).get("name").toString();
+            String sourceName = getSectionNumber(sourceList.get(i).get("name").toString());
+            String targetName = getSectionNumber(targetList.get(i).get("name").toString());
             System.out.println("Checking " + sourceName + " -> " + targetName);
             if(sourceName != null){
                 assertThat(sourceName).withFailMessage(
                         FAIL_MESSAGE,
                         pathListName,
                         sourceName,
-                        targetName).startsWith(targetName);
+                        targetName).isEqualTo(targetName);
             }
         }
     }
@@ -550,8 +550,8 @@ public class MigrationTestUtils {
         System.out.println(sourceList.size() + " -> " + targetList.size());
 
         for(int i = 0; i < sourceList.size(); i++) {
-            String sourceSection = sourceList.get(i);
-            String targetSection = targetList.get(i);
+            String sourceSection = getSectionNumber(sourceList.get(i));
+            String targetSection = getSectionNumber(targetList.get(i));
             if(sourceSection != null){
                 assertThat(sourceSection).withFailMessage(
                         FAIL_MESSAGE,

--- a/klass-api/src/test/java/no/ssb/klass/api/migration/dataintegrity/KlassApiSsbSectionsTest.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/migration/dataintegrity/KlassApiSsbSectionsTest.java
@@ -9,8 +9,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class KlassApiSsbSectionsTest extends AbstractKlassApiDataIntegrityTest {
 
-    Boolean migrated = true;
-
     @Test
     void getSsbSections(){
         String path = getSsbSectionsPath();
@@ -25,12 +23,8 @@ public class KlassApiSsbSectionsTest extends AbstractKlassApiDataIntegrityTest {
             assertThat(compareError(null, sourceResponse, targetResponse)).isTrue();
         }
         else{
-            if(migrated) {
-                validateMigratedSsbSections(sourceResponse, targetResponse);
-            }
-            else{
-                validateList(sourceResponse, targetResponse, EMBEDDED_SSB_SECTIONS);
-            }
+
+            validateMigratedSsbSections(sourceResponse, targetResponse);
             validateObject(sourceResponse, targetResponse, LINKS_SELF_HREF);
         }
     }
@@ -49,12 +43,7 @@ public class KlassApiSsbSectionsTest extends AbstractKlassApiDataIntegrityTest {
             assertThat(compareError(null, sourceResponse, targetResponse)).isTrue();
         }
         else{
-            if(migrated){
-                validateXmlMigratedSsbsections(path, sourceResponse, targetResponse);
-            }
-            else {
-                validateXmlList(path, sourceResponse, targetResponse, ENTITIES_CONTENTS_CONTENT);
-            }
+            validateXmlMigratedSsbsections(path, sourceResponse, targetResponse);
             validateXmlItems(sourceResponse, targetResponse, pathNamesXmlEntitiesLinks);
         }
     }

--- a/klass-api/src/test/java/no/ssb/klass/api/migration/dataintegrity/changes/KlassApiClassificationChangesCsvTest.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/migration/dataintegrity/changes/KlassApiClassificationChangesCsvTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static no.ssb.klass.api.migration.MigrationTestConstants.*;
 import static no.ssb.klass.api.migration.MigrationTestUtils.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class KlassApiClassificationChangesCsvTest extends AbstractKlassApiChanges {
 
@@ -36,9 +35,6 @@ public class KlassApiClassificationChangesCsvTest extends AbstractKlassApiChange
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationChanges(int classificationId) {
-
-        // Temp start at id 7 because of heavy requests to some ids
-        assumeTrue(classificationId > 6);
         String path= getChangesPath(classificationId);
         Response sourceResponse = klassApiMigrationClient.getFromSourceApi(path, paramsDate,TEXT_CSV);
         Response targetResponse = klassApiMigrationClient.getFromTargetApi(path, paramsDate,TEXT_CSV);
@@ -99,9 +95,6 @@ public class KlassApiClassificationChangesCsvTest extends AbstractKlassApiChange
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationChangesEnglish(Integer classificationId) {
-
-        // Temp start at id 7 because of heavy requests to some ids
-        assumeTrue(classificationId > 6);
         String path= getChangesPath(classificationId);
         Response sourceResponse = klassApiMigrationClient.getFromSourceApi(path, paramsLanguageEn,TEXT_CSV);
         Response targetResponse = klassApiMigrationClient.getFromTargetApi(path, paramsLanguageEn,TEXT_CSV);
@@ -121,9 +114,6 @@ public class KlassApiClassificationChangesCsvTest extends AbstractKlassApiChange
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationChangesNewNorwegian(Integer classificationId) {
-
-        // Temp start at id 7 because of heavy requests to some ids
-        assumeTrue(classificationId > 6);
         String path= getChangesPath(classificationId);
         Response sourceResponse = klassApiMigrationClient.getFromSourceApi(path, paramsLanguageNn,TEXT_CSV);
         Response targetResponse = klassApiMigrationClient.getFromTargetApi(path, paramsLanguageNn,TEXT_CSV);
@@ -143,9 +133,6 @@ public class KlassApiClassificationChangesCsvTest extends AbstractKlassApiChange
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationChangesCsvSeparator(Integer classificationId) {
-
-        // Temp start at id 7 because of heavy requests to some ids
-        assumeTrue(classificationId > 6);
         String path= getChangesPath(classificationId);
         Response sourceResponse = klassApiMigrationClient.getFromSourceApi(path, paramsCsvSeparator,TEXT_CSV);
         Response targetResponse = klassApiMigrationClient.getFromTargetApi(path, paramsCsvSeparator,TEXT_CSV);

--- a/klass-api/src/test/java/no/ssb/klass/api/migration/dataintegrity/changes/KlassApiClassificationChangesJsonTest.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/migration/dataintegrity/changes/KlassApiClassificationChangesJsonTest.java
@@ -10,7 +10,6 @@ import java.time.Instant;
 import static no.ssb.klass.api.migration.MigrationTestConstants.*;
 import static no.ssb.klass.api.migration.MigrationTestUtils.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class KlassApiClassificationChangesJsonTest extends AbstractKlassApiChanges {
 
@@ -37,9 +36,6 @@ public class KlassApiClassificationChangesJsonTest extends AbstractKlassApiChang
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationChanges(int classificationId) {
-
-        // Temp start at id 7 because of heavy requests to some ids
-        assumeTrue(classificationId > 6);
         System.out.println("Start test for ID " + classificationId + " at " + Instant.now());
 
         String path= getChangesPath(classificationId);
@@ -63,9 +59,6 @@ public class KlassApiClassificationChangesJsonTest extends AbstractKlassApiChang
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getOneClassificationChangesDatesInRange(int classificationId) {
-        // Temp start at id 7 because of heavy requests to some ids
-        assumeTrue(classificationId > 6);
-
         String path= getChangesPath(classificationId);
         Response sourceResponse = klassApiMigrationClient.getFromSourceApi(path, paramsDateInRange,null);
         Response targetResponse = klassApiMigrationClient.getFromTargetApi(path, paramsDateInRange,null);
@@ -86,9 +79,6 @@ public class KlassApiClassificationChangesJsonTest extends AbstractKlassApiChang
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationChangesEnglish(int classificationId) {
-
-        // Temp start at id 7 because of heavy requests to some ids
-        assumeTrue(classificationId > 6);
         String path= getChangesPath(classificationId);
         Response sourceResponse = klassApiMigrationClient.getFromSourceApi(path, paramsLanguageEn,null);
         Response targetResponse = klassApiMigrationClient.getFromTargetApi(path, paramsLanguageEn,null);
@@ -108,9 +98,6 @@ public class KlassApiClassificationChangesJsonTest extends AbstractKlassApiChang
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationChangesNewNorwegian(int classificationId) {
-
-        // Temp start at id 7 because of heavy requests to some ids
-        assumeTrue(classificationId > 6);
         String path= getChangesPath(classificationId);
         Response sourceResponse = klassApiMigrationClient.getFromSourceApi(path, paramsLanguageNn,null);
         Response targetResponse = klassApiMigrationClient.getFromTargetApi(path, paramsLanguageNn,null);
@@ -130,10 +117,6 @@ public class KlassApiClassificationChangesJsonTest extends AbstractKlassApiChang
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationChangesIncludeFuture(int classificationId) {
-
-        // Temp start at id 7 because of heavy requests to some ids
-        assumeTrue(classificationId > 6);
-
         String path= getChangesPath(classificationId);
         Response sourceResponse = klassApiMigrationClient.getFromSourceApi(path, paramsIncludeFuture,null);
         Response targetResponse = klassApiMigrationClient.getFromTargetApi(path, paramsIncludeFuture,null);

--- a/klass-api/src/test/java/no/ssb/klass/api/migration/dataintegrity/changes/KlassApiClassificationChangesXmlTest.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/migration/dataintegrity/changes/KlassApiClassificationChangesXmlTest.java
@@ -10,7 +10,6 @@ import java.time.Instant;
 import static no.ssb.klass.api.migration.MigrationTestConstants.*;
 import static no.ssb.klass.api.migration.MigrationTestUtils.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class KlassApiClassificationChangesXmlTest extends AbstractKlassApiChanges {
 
@@ -41,9 +40,6 @@ public class KlassApiClassificationChangesXmlTest extends AbstractKlassApiChange
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationChanges(int classificationId) {
 
-        // Temp start at id 7 because of heavy requests to some ids
-        assumeTrue(classificationId > 6);
-
         String path= getChangesPath(classificationId);
         Response sourceResponse = klassApiMigrationClient.getFromSourceApi(path, paramsDate, APPLICATION_XML);
         Response targetResponse = klassApiMigrationClient.getFromTargetApi(path, paramsDate, APPLICATION_XML);
@@ -65,9 +61,6 @@ public class KlassApiClassificationChangesXmlTest extends AbstractKlassApiChange
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationChangesDatesInRange(int classificationId) {
 
-        // Temp start at id 7 because of heavy requests to some ids
-        assumeTrue(classificationId > 6);
-
         String path= getChangesPath(classificationId);
         Response sourceResponse = klassApiMigrationClient.getFromSourceApi(path, paramsDateInRange,APPLICATION_XML);
         Response targetResponse = klassApiMigrationClient.getFromTargetApi(path, paramsDateInRange,APPLICATION_XML);
@@ -88,10 +81,6 @@ public class KlassApiClassificationChangesXmlTest extends AbstractKlassApiChange
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationChangesLanguageEn(int classificationId) {
-
-        // Temp start at id 7 because of heavy requests to some ids
-        assumeTrue(classificationId > 6);
-
         String path= getChangesPath(classificationId);
         Response sourceResponse = klassApiMigrationClient.getFromSourceApi(path, paramsLanguageEn,APPLICATION_XML);
         Response targetResponse = klassApiMigrationClient.getFromTargetApi(path, paramsLanguageEn,APPLICATION_XML);
@@ -111,10 +100,6 @@ public class KlassApiClassificationChangesXmlTest extends AbstractKlassApiChange
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationChangesLanguageNn(int classificationId) {
-
-        // Temp start at id 7 because of heavy requests to some ids
-        assumeTrue(classificationId > 6);
-
         String path= getChangesPath(classificationId);
         Response sourceResponse = klassApiMigrationClient.getFromSourceApi(path, paramsLanguageNn,APPLICATION_XML);
         Response targetResponse = klassApiMigrationClient.getFromTargetApi(path, paramsLanguageNn,APPLICATION_XML);

--- a/klass-api/src/test/java/no/ssb/klass/api/migration/dataintegrity/codes/KlassApiClassificationCodesCsvTest.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/migration/dataintegrity/codes/KlassApiClassificationCodesCsvTest.java
@@ -11,7 +11,6 @@ import static no.ssb.klass.api.migration.MigrationTestConstants.*;
 import static no.ssb.klass.api.migration.MigrationTestConstants.TEXT_CSV;
 import static no.ssb.klass.api.migration.MigrationTestUtils.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class KlassApiClassificationCodesCsvTest extends AbstractKlassApiCodesTest {
 
@@ -38,9 +37,6 @@ public class KlassApiClassificationCodesCsvTest extends AbstractKlassApiCodesTes
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationWithCodesCsv(Integer classificationId) {
-        // For now skipping because of some items size
-        assumeTrue(classificationId > 6);
-
         System.out.println("Start test for ID " + classificationId + " at " + Instant.now());
 
         String path = getCodesPath(classificationId);

--- a/klass-api/src/test/java/no/ssb/klass/api/migration/dataintegrity/codes/KlassApiClassificationCodesJsonTest.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/migration/dataintegrity/codes/KlassApiClassificationCodesJsonTest.java
@@ -10,7 +10,6 @@ import java.time.Instant;
 import static no.ssb.klass.api.migration.MigrationTestConstants.*;
 import static no.ssb.klass.api.migration.MigrationTestUtils.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class KlassApiClassificationCodesJsonTest extends AbstractKlassApiCodesTest {
 
@@ -38,9 +37,6 @@ public class KlassApiClassificationCodesJsonTest extends AbstractKlassApiCodesTe
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationWithCodes(Integer classificationId) {
-        // For now skipping because of some items size
-        assumeTrue(classificationId > 6);
-
         System.out.println("Start test for ID " + classificationId + " at " + Instant.now());
 
         String path = getCodesPath(classificationId);
@@ -64,11 +60,28 @@ public class KlassApiClassificationCodesJsonTest extends AbstractKlassApiCodesTe
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationWithCodesInRange(Integer classificationId) {
-
-        // For now skipping because of some items size
-        assumeTrue(classificationId > 6);
         System.out.println("Start test for ID " + classificationId + " at " + Instant.now());
 
+        String path = getCodesPath(classificationId);
+        Response sourceResponse = klassApiMigrationClient.getFromSourceApi(path, paramsDateInRange,null);
+        Response targetResponse = klassApiMigrationClient.getFromTargetApi(path, paramsDateInRange,null);
+
+        assertApiResponseIsNotNull(sourceResponse);
+
+        assertStatusCodesEqual(sourceResponse.getStatusCode(), targetResponse.getStatusCode(), path);
+
+        if(sourceResponse.getStatusCode() != 200) {
+            assertThat(compareError(classificationId, sourceResponse, targetResponse)).isTrue();
+        }
+        else{
+            validateList(sourceResponse, targetResponse, CODES);
+        }
+    }
+
+    @Test
+    void getOneClassificationWithCodesInRange() {
+
+        int classificationId= 36;
         String path = getCodesPath(classificationId);
         Response sourceResponse = klassApiMigrationClient.getFromSourceApi(path, paramsDateInRange,null);
         Response targetResponse = klassApiMigrationClient.getFromTargetApi(path, paramsDateInRange,null);

--- a/klass-api/src/test/java/no/ssb/klass/api/migration/dataintegrity/codes/KlassApiClassificationCodesXmlTest.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/migration/dataintegrity/codes/KlassApiClassificationCodesXmlTest.java
@@ -11,7 +11,6 @@ import static no.ssb.klass.api.migration.MigrationTestConstants.*;
 import static no.ssb.klass.api.migration.MigrationTestConstants.APPLICATION_XML;
 import static no.ssb.klass.api.migration.MigrationTestUtils.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class KlassApiClassificationCodesXmlTest extends AbstractKlassApiCodesTest {
 
@@ -39,8 +38,6 @@ public class KlassApiClassificationCodesXmlTest extends AbstractKlassApiCodesTes
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationWithCodes(Integer classificationId) {
-        // For now skipping because of some items size
-        assumeTrue(classificationId > 6);
 
         System.out.println("Start test for ID " + classificationId + " at " + Instant.now());
 
@@ -65,9 +62,6 @@ public class KlassApiClassificationCodesXmlTest extends AbstractKlassApiCodesTes
     @ParameterizedTest
     @MethodSource("rangeProviderClassificationIds")
     void getClassificationWithCodesInRange(Integer classificationId) {
-
-        // For now skipping because of some items size
-        assumeTrue(classificationId > 6);
         System.out.println("Start test for ID " + classificationId + " at " + Instant.now());
 
         String path = getCodesPath(classificationId);

--- a/klass-shared/docker-compose.yaml
+++ b/klass-shared/docker-compose.yaml
@@ -32,11 +32,8 @@ services:
       - postgresql
     ports:
       - "8080:8080"
-    deploy:
-      resources:
-        limits:
-          cpus: "1.0"
-          memory: 1G
+    mem_limit: 2g
+    cpus: 1.0
     environment:
       SPRING_PROFILES_ACTIVE: api, postgres-local, skip-indexing, embedded-solr
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}

--- a/klass-shared/docker-compose.yaml
+++ b/klass-shared/docker-compose.yaml
@@ -26,13 +26,13 @@ services:
     build:
       context: ../klass-api
       dockerfile: ../klass-api/Dockerfile
-    command: [ "java", "-jar", "app.war" ]
+    command: [ "java", "-Xms1g", "-jar", "app.war" ]
     profiles: [ migration-testing, api ]
     depends_on:
       - postgresql
     ports:
       - "8080:8080"
-    mem_limit: 2g
+    mem_limit: 4g
     cpus: 1.0
     environment:
       SPRING_PROFILES_ACTIVE: api, postgres-local, skip-indexing, embedded-solr
@@ -47,11 +47,8 @@ services:
       - mariadb
     ports:
       - "8082:8080"
-    deploy:
-      resources:
-        limits:
-          cpus: "1.0"
-          memory: 1G
+    mem_limit: 4g
+    cpus: 1.0
     environment:
       MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD}
       MARIADB_USER: "klass"
@@ -72,11 +69,7 @@ services:
     ports:
       - "8080:8080"
     mem_limit: 8g
-    deploy:
-      resources:
-        limits:
-          cpus: "1.0"
-          memory: 8G
+    cpus: 1.0
     environment:
       SPRING_PROFILES_ACTIVE: "api, postgres-local"
       SPRING_DATA_SOLR_HOST: http://solr:8983/solr


### PR DESCRIPTION
- **re add testing for id 1-6** -> these where previous excluded because they consumed too much memory
- **ssb sections can only compare section code since klass is using a more recent codelist for names**
- **increase memory in container - deploy is only for docker swarm**

