### PR TITLE
Correct owning section code

### DIFF
--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationVariantResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationVariantResource.java
@@ -34,7 +34,7 @@ public class ClassificationVariantResource extends ClassificationVariantSummaryR
             ClassificationVariant variant,
             Language language,
             String owningSectionName) {
-        super(variant, language, owningSectionName);
+        super(variant, language);
         this.validFrom = variant.getDateRange().getFrom();
         LocalDate to = variant.getDateRange().getTo();
         this.validTo = (to.isEqual(LocalDate.MAX)) ? null : to;
@@ -44,7 +44,7 @@ public class ClassificationVariantResource extends ClassificationVariantSummaryR
 
         this.levels = LevelResource.convert(variant.getLevels(), language);
         this.correspondenceTables = CorrespondenceTableSummaryResource.convert(variant.getCorrespondenceTables(),
-                language, owningSectionName);
+                language);
         this.classificationItems = ClassificationItemResource.convert(variant, language);
         this.changelogs = ChangelogResource.convert(variant.getChangelogs());
     }

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationVariantSummaryResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationVariantSummaryResource.java
@@ -29,13 +29,12 @@ public class ClassificationVariantSummaryResource extends KlassResource {
 
     protected ClassificationVariantSummaryResource(
             ClassificationVariant variant,
-            Language language,
-            String owningSectionName) {
+            Language language) {
         super(variant.getId());
         this.name = variant.getFullName(language);
         this.lastModified = variant.getLastModified();
         this.contactPerson = new ContactPersonResource(variant.getContactPerson());
-        this.owningSection = owningSectionName;
+        this.owningSection = variant.getContactPerson().getSection();
         this.published = Arrays.stream(Language.getDefaultPrioritizedOrder())
                 .filter(variant::isPublished)
                 .map(Language::getLanguageCode)
@@ -71,8 +70,8 @@ public class ClassificationVariantSummaryResource extends KlassResource {
     }
 
     public static List<ClassificationVariantSummaryResource> convert(List<ClassificationVariant> variants,
-            Language language, String owningSectionName) {
-        return variants.stream().map(variant -> new ClassificationVariantSummaryResource(variant, language, owningSectionName)).collect(
+            Language language) {
+        return variants.stream().map(variant -> new ClassificationVariantSummaryResource(variant, language)).collect(
                 Collectors.toList());
     }
 }

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationVersionResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ClassificationVersionResource.java
@@ -62,9 +62,9 @@ public class ClassificationVersionResource extends ClassificationVersionSummaryR
 
 
         this.correspondenceTables = CorrespondenceTableSummaryResource
-                .convert(publicCorrespondenceTables, language, owningSectionName);
+                .convert(publicCorrespondenceTables, language);
         this.classificationVariants = ClassificationVariantSummaryResource
-                .convert(version.getPublicClassificationVariants(), language, owningSectionName);
+                .convert(version.getPublicClassificationVariants(), language);
         this.classificationItems = ClassificationItemResource.convert(version, language);
         this.changelogs = ChangelogResource.convert(version.getChangelogs());
     }

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/CorrespondenceTableResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/CorrespondenceTableResource.java
@@ -17,12 +17,13 @@ import no.ssb.klass.core.model.Language;
 public class CorrespondenceTableResource extends CorrespondenceTableSummaryResource {
     private final String description;
     private final List<ChangelogResource> changelogs;
-
-
+    private final String owningSection;
     private final List<CorrespondenceMapResource> correspondenceMaps;
 
     public CorrespondenceTableResource(CorrespondenceTable correspondenceTable, Language language, String owningSectionName) {
-        super(correspondenceTable, language,owningSectionName);
+        super(correspondenceTable, language);
+        //  super(correspondenceTable, language,owningSectionName);
+        this.owningSection = owningSectionName;
         this.description = correspondenceTable.getDescription(language);
         this.correspondenceMaps = CorrespondenceMapResource.convert(correspondenceTable.getCorrespondenceMaps(),
                 language);
@@ -31,6 +32,10 @@ public class CorrespondenceTableResource extends CorrespondenceTableSummaryResou
 
     public String getDescription() {
         return description;
+    }
+
+    public String getOwningSection() {
+        return owningSection;
     }
 
     @JacksonXmlElementWrapper(localName = "changelogs")

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/CorrespondenceTableResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/CorrespondenceTableResource.java
@@ -22,7 +22,6 @@ public class CorrespondenceTableResource extends CorrespondenceTableSummaryResou
 
     public CorrespondenceTableResource(CorrespondenceTable correspondenceTable, Language language, String owningSectionName) {
         super(correspondenceTable, language);
-        //  super(correspondenceTable, language,owningSectionName);
         this.owningSection = owningSectionName;
         this.description = correspondenceTable.getDescription(language);
         this.correspondenceMaps = CorrespondenceMapResource.convert(correspondenceTable.getCorrespondenceMaps(),

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/CorrespondenceTableSummaryResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/CorrespondenceTableSummaryResource.java
@@ -130,9 +130,5 @@ public class CorrespondenceTableSummaryResource extends KlassResource {
             Language language) {
         return correspondenceTables.stream().map(c -> new CorrespondenceTableSummaryResource(c, language)).collect(
                 Collectors.toList());
-        /*
-           return correspondenceTables.stream().map(c -> new CorrespondenceTableSummaryResource(c, language, owningSectionName)).collect(
-                Collectors.toList());
-         */
     }
 }

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/CorrespondenceTableSummaryResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/CorrespondenceTableSummaryResource.java
@@ -38,12 +38,11 @@ public class CorrespondenceTableSummaryResource extends KlassResource {
 
     protected CorrespondenceTableSummaryResource(
             CorrespondenceTable correspondenceTable,
-            Language language,
-            String owningSectionName) {
+            Language language) {
         super(correspondenceTable.getId());
         this.name = correspondenceTable.getName(language);
         this.contactPerson = new ContactPersonResource(correspondenceTable.getContactPerson());
-        this.owningSection = owningSectionName;
+        this.owningSection = correspondenceTable.getContactPerson().getSection();
         this.source = correspondenceTable.getSource().getName(language);
         this.sourceId = correspondenceTable.getSource().getId();
         this.target = correspondenceTable.getTarget().getName(language);
@@ -128,8 +127,12 @@ public class CorrespondenceTableSummaryResource extends KlassResource {
     }
 
     public static List<CorrespondenceTableSummaryResource> convert(List<CorrespondenceTable> correspondenceTables,
-            Language language, String owningSectionName) {
-        return correspondenceTables.stream().map(c -> new CorrespondenceTableSummaryResource(c, language, owningSectionName)).collect(
+            Language language) {
+        return correspondenceTables.stream().map(c -> new CorrespondenceTableSummaryResource(c, language)).collect(
                 Collectors.toList());
+        /*
+           return correspondenceTables.stream().map(c -> new CorrespondenceTableSummaryResource(c, language, owningSectionName)).collect(
+                Collectors.toList());
+         */
     }
 }

--- a/klass-api/src/test/java/no/ssb/klass/api/applicationtest/AbstractRestApiApplicationTest.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/applicationtest/AbstractRestApiApplicationTest.java
@@ -5,10 +5,7 @@ import no.ssb.klass.api.applicationtest.config.ApplicationTestConfig;
 import no.ssb.klass.api.applicationtest.utils.ApplicationTestUtil;
 import no.ssb.klass.api.util.RestConstants;
 import no.ssb.klass.core.config.ConfigurationProfiles;
-import no.ssb.klass.core.model.ClassificationFamily;
-import no.ssb.klass.core.model.ClassificationSeries;
-import no.ssb.klass.core.model.CorrespondenceTable;
-import no.ssb.klass.core.model.User;
+import no.ssb.klass.core.model.*;
 import no.ssb.klass.core.repository.ClassificationFamilyRepository;
 import no.ssb.klass.core.repository.ClassificationSeriesRepository;
 import no.ssb.klass.core.repository.CorrespondenceTableRepository;
@@ -62,6 +59,9 @@ public abstract class AbstractRestApiApplicationTest {
 
     public static final String REQUEST_CORRESPONDENCE_TABLES = RestConstants.API_VERSION_V1
             + "/correspondencetables/{correspondencetablesId}";
+
+    public static final String REQUEST_VERSIONS_WITH_ID = RestConstants.API_VERSION_V1
+            + "/versions/{versionsId}";
 
     public static final String REQUEST_SSB_SECTION = RestConstants.API_VERSION_V1 + "/ssbsections";
 
@@ -118,6 +118,7 @@ public abstract class AbstractRestApiApplicationTest {
     protected ClassificationSeries familieGrupperingCodelist;
     protected ClassificationFamily classificationFamily;
     protected CorrespondenceTable correspondenceTable;
+    protected ClassificationSeries badmintonCodelist;
 
     @Autowired
     protected ApplicationTestUtil applicationTestUtil;
@@ -143,6 +144,8 @@ public abstract class AbstractRestApiApplicationTest {
         applicationTestUtil.clearSearch();
         // if (!testDataInitialized) {
         User user = userRepository.save(TestUtil.createUser());
+        User user2 = userRepository.save(TestUtil.createUser2());
+        User user3 = userRepository.save(TestUtil.createUser3());
         TimeUtil.setClockSource(new ConstantClockSource(parseDate(CHANGED_SINCE_OLD_DATE)));
         classificationFamily = classificationFamilyRepository.save(TestUtil
                 .createClassificationFamily("Befolkning"));
@@ -157,6 +160,10 @@ public abstract class AbstractRestApiApplicationTest {
         familieGrupperingCodelist = TestDataProvider.createFamiliegrupperingCodelist(user);
         classificationFamily.addClassificationSeries(familieGrupperingCodelist);
         classificationService.saveAndIndexClassification(familieGrupperingCodelist);
+
+        badmintonCodelist = TestDataProvider.createBadmintonCodelist(user,user2, user3);
+        classificationFamily.addClassificationSeries(badmintonCodelist);
+        classificationService.saveAndIndexClassification(badmintonCodelist);
 
         kommuneinndeling = classificationService.saveAndIndexClassification(kommuneinndeling);
         bydelsinndeling = classificationService.saveAndIndexClassification(bydelsinndeling);

--- a/klass-api/src/test/java/no/ssb/klass/api/applicationtest/AbstractRestApiApplicationTest.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/applicationtest/AbstractRestApiApplicationTest.java
@@ -83,11 +83,13 @@ public abstract class AbstractRestApiApplicationTest {
     public static final String JSON_CLASSIFICATION1 = "_embedded.classifications[0]";
     public static final String JSON_CLASSIFICATION2 = "_embedded.classifications[1]";
     public static final String JSON_CLASSIFICATION3 = "_embedded.classifications[2]";
+    public static final String JSON_CLASSIFICATION4 = "_embedded.classifications[3]";
 
     public static final String XML_CLASSIFICATIONS = "PagedResources.contents.content";
     public static final String XML_CLASSIFICATION1 = "PagedResources.contents.content[0]";
     public static final String XML_CLASSIFICATION2 = "PagedResources.contents.content[1]";
     public static final String XML_CLASSIFICATION3 = "PagedResources.contents.content[2]";
+    public static final String XML_CLASSIFICATION4 = "PagedResources.contents.content[3]";
 
     public static final String JSON_PAGE = "page";
     public static final String XML_PAGE = "PagedResources.page";

--- a/klass-api/src/test/java/no/ssb/klass/api/applicationtest/RestApiListClassificationIntegrationTest.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/applicationtest/RestApiListClassificationIntegrationTest.java
@@ -49,23 +49,23 @@ public class RestApiListClassificationIntegrationTest extends AbstractRestApiApp
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .contentType(ContentType.JSON)
-                .body(JSON_CLASSIFICATIONS + ".size()", equalTo(3))
+                .body(JSON_CLASSIFICATIONS + ".size()", equalTo(4))
                 // result 1
                 .body(JSON_CLASSIFICATION1 + ".name", equalTo(TestDataProvider.FAMILIEGRUPPERING_NAVN_NO))
                 .body(JSON_CLASSIFICATION1 + "._links.self.href", containsString(REQUEST + "/" + familieGrupperingCodelist.getId()))
                 //result 2
-                .body(JSON_CLASSIFICATION2 + ".name", equalTo(TestDataProvider.KOMMUNEINNDELING_NAVN_NO))
-                .body(JSON_CLASSIFICATION2 + "._links.self.href", containsString(REQUEST + "/" + kommuneinndeling.getId()))
+                .body(JSON_CLASSIFICATION3 + ".name", equalTo(TestDataProvider.KOMMUNEINNDELING_NAVN_NO))
+                .body(JSON_CLASSIFICATION3 + "._links.self.href", containsString(REQUEST + "/" + kommuneinndeling.getId()))
                 //result 3
-                .body(JSON_CLASSIFICATION3 + ".name", equalTo(TestDataProvider.BYDELSINNDELING_NAVN_NO))
-                .body(JSON_CLASSIFICATION3 + "._links.self.href", containsString(REQUEST + "/" + bydelsinndeling.getId()))
+                .body(JSON_CLASSIFICATION4 + ".name", equalTo(TestDataProvider.BYDELSINNDELING_NAVN_NO))
+                .body(JSON_CLASSIFICATION4 + "._links.self.href", containsString(REQUEST + "/" + bydelsinndeling.getId()))
 
                 // links
                 .body(JSON_LINKS + ".self.href", containsString(REQUEST))
                 .body(JSON_LINKS + ".search.href", containsString(REQUEST_SEARCH))
                 //paging
                 .body(JSON_PAGE + ".size", equalTo(20))
-                .body(JSON_PAGE + ".totalElements", equalTo(3))
+                .body(JSON_PAGE + ".totalElements", equalTo(4))
                 .body(JSON_PAGE + ".totalPages", equalTo(1))
                 .body(JSON_PAGE + ".number", equalTo(0));
     }
@@ -133,19 +133,19 @@ public class RestApiListClassificationIntegrationTest extends AbstractRestApiApp
                 .then()
                 .statusCode(HttpStatus.OK.value())
                 .contentType(ContentType.XML)
-                .body(XML_CLASSIFICATIONS + ".size()", equalTo(3))
+                .body(XML_CLASSIFICATIONS + ".size()", equalTo(4))
                 // result 1
                 .body(XML_CLASSIFICATION1 + ".name", equalTo(TestDataProvider.FAMILIEGRUPPERING_NAVN_NO))
                 .body(XML_CLASSIFICATION1 + ".link.rel", equalTo("self"))
                 .body(XML_CLASSIFICATION1 + ".link.href", containsString(REQUEST + "/" + familieGrupperingCodelist.getId()))
                 //result 2
-                .body(XML_CLASSIFICATION2 + ".name", equalTo(TestDataProvider.KOMMUNEINNDELING_NAVN_NO))
-                .body(XML_CLASSIFICATION2 + ".link.rel", equalTo("self"))
-                .body(XML_CLASSIFICATION2 + ".link.href", containsString(REQUEST + "/" + kommuneinndeling.getId()))
-                //result 3
-                .body(XML_CLASSIFICATION3 + ".name", equalTo(TestDataProvider.BYDELSINNDELING_NAVN_NO))
+                .body(XML_CLASSIFICATION3 + ".name", equalTo(TestDataProvider.KOMMUNEINNDELING_NAVN_NO))
                 .body(XML_CLASSIFICATION3 + ".link.rel", equalTo("self"))
-                .body(XML_CLASSIFICATION3 + ".link.href", containsString(REQUEST + "/" + bydelsinndeling.getId()))
+                .body(XML_CLASSIFICATION3 + ".link.href", containsString(REQUEST + "/" + kommuneinndeling.getId()))
+                //result 3
+                .body(XML_CLASSIFICATION4 + ".name", equalTo(TestDataProvider.BYDELSINNDELING_NAVN_NO))
+                .body(XML_CLASSIFICATION4 + ".link.rel", equalTo("self"))
+                .body(XML_CLASSIFICATION4 + ".link.href", containsString(REQUEST + "/" + bydelsinndeling.getId()))
 
                 // links
                 .body(XML_ROOT + ".link[0].rel", equalTo("self"))
@@ -154,7 +154,7 @@ public class RestApiListClassificationIntegrationTest extends AbstractRestApiApp
                 .body(XML_ROOT + ".link[1].href", containsString(REQUEST_SEARCH))
                 // paging
                 .body(XML_PAGE + ".size.toInteger();", equalTo(20))
-                .body(XML_PAGE + ".totalElements.toInteger();", equalTo(3))
+                .body(XML_PAGE + ".totalElements.toInteger();", equalTo(4))
                 .body(XML_PAGE + ".totalPages.toInteger();", equalTo(1))
                 .body(XML_PAGE + ".number.toInteger();", equalTo(0));
     }

--- a/klass-api/src/test/java/no/ssb/klass/api/applicationtest/RestApiVersionsIntegrationTest.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/applicationtest/RestApiVersionsIntegrationTest.java
@@ -1,0 +1,25 @@
+package no.ssb.klass.api.applicationtest;
+
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+public class RestApiVersionsIntegrationTest extends AbstractRestApiApplicationTest {
+    @Test
+    public void restServiceVersionsJSON() {
+        given().port(port).accept(ContentType.JSON)
+                .param("language", "nb")
+                .get(REQUEST_VERSIONS_WITH_ID , badmintonCodelist.getNewestVersion().getId())
+                .then()
+                .contentType(ContentType.JSON)
+                .statusCode(HttpStatus.OK.value())
+                .body("name", is("Badminton 2006"))
+                .body("contactPerson.name", is("Ziggy Stardust"))
+                .body("owningSection", is("section"))
+                .body("classificationVariants[0].owningSection", is("425"))
+                .body("classificationVariants[1].owningSection", is("150"));
+    }
+}

--- a/klass-shared/src/test/java/no/ssb/klass/testutil/TestDataProvider.java
+++ b/klass-shared/src/test/java/no/ssb/klass/testutil/TestDataProvider.java
@@ -238,6 +238,37 @@ public final class TestDataProvider {
         return classification;
     }
 
+    public static ClassificationSeries createBadmintonCodelist(User user, User user1, User user2 ) {
+        ClassificationSeries classification = TestUtil.createCodelist("badminton",
+                "Testing when version owning section is different from variant owning section");
+
+        classification.setContactPerson(user);
+        ClassificationVersion version = TestUtil.createClassificationVersion(DateRange.create("2006-01-01", TestDataProvider.TEN_YEARS_LATER_DATE));
+        Level level = TestUtil.createLevel(1);
+        version.addLevel(level);
+        version.addClassificationItem(TestUtil.createClassificationItem("0.1.1", "Fjærballer pro"),
+                level.getLevelNumber(), null);
+        ClassificationVariant variant = TestUtil.createClassificationVariant(
+                "Variant - Tilleggsinndeling for baller", user1);
+        variant.addClassificationItem(TestUtil.createClassificationItem("A", "Fjærball"), 1, null);
+        variant.addClassificationItem(TestUtil.createClassificationItem("B", "Tennisball"), 1, null);
+        variant.addClassificationItem(TestUtil.createClassificationItem("A_", "Fjærball"), 2, variant.findItem(
+                "A"));
+        variant.addClassificationItem(TestUtil.createClassificationItem("BA", "Tennisball med fjær"),
+                2, variant.findItem("B"));
+        variant.addClassificationItem(TestUtil.createClassificationItem("BB", "Tennisball pro"), 2, variant
+                .findItem("B"));
+        version.addClassificationVariant(variant);
+        ClassificationVariant variant2 = TestUtil.createClassificationVariant(
+                "Variant - Tilleggsinndeling for racketer", user2);
+        variant2.addClassificationItem(TestUtil.createClassificationItem("Q", "Lang racket"), 1, null);
+        variant2.addClassificationItem(TestUtil.createClassificationItem("B", "Kort racket"), 1, null);
+        version.addClassificationVariant(variant2);
+        classification.addClassificationVersion(version);
+
+        return classification;
+    }
+
     public static ClassificationVersion createFamiliegrupperingFutureVersion(User user) {
 
         ClassificationVersion version = TestUtil.createClassificationVersion(DateRange.create(TestDataProvider.TEN_YEARS_LATER_DATE, null));

--- a/klass-shared/src/test/java/no/ssb/klass/testutil/TestDataProvider.java
+++ b/klass-shared/src/test/java/no/ssb/klass/testutil/TestDataProvider.java
@@ -239,7 +239,7 @@ public final class TestDataProvider {
     }
 
     public static ClassificationSeries createBadmintonCodelist(User user, User user1, User user2 ) {
-        ClassificationSeries classification = TestUtil.createCodelist("badminton",
+        ClassificationSeries classification = TestUtil.createCodelist("Badminton",
                 "Testing when version owning section is different from variant owning section");
 
         classification.setContactPerson(user);

--- a/klass-shared/src/test/java/no/ssb/klass/testutil/TestUtil.java
+++ b/klass-shared/src/test/java/no/ssb/klass/testutil/TestUtil.java
@@ -147,6 +147,14 @@ public final class TestUtil {
         return new User("ziggy", "Ziggy Stardust", "section");
     }
 
+    public static User createUser2() {
+        return new User("sig", "Sigrid Clouddust", "425");
+    }
+
+    public static User createUser3() {
+        return new User("hik", "Hikke Airballoon", "150");
+    }
+
     public static DateRange anyDateRange() {
         return DateRange.create(TimeUtil.createDate("2012-01-01"), TimeUtil.createDate("2015-01-01"));
     }


### PR DESCRIPTION
Fix error where summary resources inherited `owningSection` from primary resource.

- Do not resolve owning section name for any summary resources. These will return raw section code
- add test and test data

Paths affected:
- `versions/{id}` -> `classificationVariants`and `correspondenceTables`
- `variants/{id}` ->  `correspondenceTables`

`/versions/14`
<img width="562" height="348" alt="Screenshot 2025-09-03 at 08 31 08" src="https://github.com/user-attachments/assets/a07154fe-2035-40cd-8cf3-64ab954627e9" />

`versions/30`
<img width="758" height="914" alt="Screenshot 2025-09-03 at 08 30 35" src="https://github.com/user-attachments/assets/921c4515-c0ec-42b9-9480-54bf4d088793" />

