### PR TITLE
Increase max body size

### DIFF
--- a/.nais/prod/klass-forvaltning.yaml
+++ b/.nais/prod/klass-forvaltning.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: dapla-metadata
   labels:
     team: dapla-metadata
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "8m"
 spec:
   port: 8081
   ingresses:


### PR DESCRIPTION
Tested in Test with successfully uploading the file
- Increase max body size to 8m in prod

Ref: Purservice case 119341

User could not upload xml file. The reason was that the file was too big and returned a 413. The error was not displayed directly to the user, the selected file just "vanished", but it was logged in console.
The file was approximately 4m

[Nais](https://doc.nais.io/workloads/application/reference/ingress/?h=#custom-max-body-size) sets default 1m.
