### PR TITLE
Klass-solr test: More memory and more heap

### DIFF
--- a/.nais/test/klass-solr.yaml
+++ b/.nais/test/klass-solr.yaml
@@ -16,6 +16,9 @@ spec:
   filesFrom:
     - persistentVolumeClaim: klass-solr-pvc
       mountPath: /opt/solr/server/solr/mycores/Klass/data
+  env:
+    - name: JAVA_TOOL_OPTIONS
+      value: "-XX:InitialRAMPercentage=50.0 -XX:MaxRAMPercentage=50.0"
 
   replicas:
     min: 1
@@ -23,9 +26,9 @@ spec:
   resources:
     requests:
       cpu: 100m
-      memory: 576Mi
+      memory: 2Gi
     limits:
-      memory: 640Mi
+      memory: 2Gi
 
   accessPolicy:
     inbound:


### PR DESCRIPTION
Certain search queries were causing heap starvation in prod. To alleviate this we:

- Increase total memory available
- Increase proportion available for heap to 50% of total

If this looks good in test we will progress to prod

Utilization graph under heap starvation:

<img width="207" height="184" alt="Screenshot 2025-09-16 at 10 19 56" src="https://github.com/user-attachments/assets/b4079775-6353-41a2-bf1f-8804a63eef6b" />
