### PR TITLE
Klass-api prod: reduce CPU request

### DIFF
--- a/.nais/prod/klass-api.yaml
+++ b/.nais/prod/klass-api.yaml
@@ -15,7 +15,7 @@ spec:
     max: 2
   resources:
     requests:
-      cpu: 840m
+      cpu: 200m
       memory: 2000Mi
     limits:
       memory: 2400Mi

--- a/.nais/test/klass-api.yaml
+++ b/.nais/test/klass-api.yaml
@@ -15,10 +15,10 @@ spec:
     max: 1
   resources:
     requests:
-      cpu: 840m
-      memory: 2000Mi
+      cpu: 200m
+      memory: 1200Mi
     limits:
-      memory: 2400Mi
+      memory: 1400Mi
   gcp:
     sqlInstances:
       - type: POSTGRES_17


### PR DESCRIPTION
By observation, this is an appropriate level to set the CPU request to. Very occasionally does the app use slightly more than the request, this is acceptable in short periods when running on Kubernetes.
