### PR TITLE
Use valid roles flyway migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ The apps can be run in multiple different configurations with Docker Compose. Se
 
 There are tasks available in the Makefile as well.
 
+#### Flyway migration
+Flyway runs when creating database locally. This is important to ensure local database behaves like deployed database.
+To work around flyway migration `V4__grant_user_role.sql` which will fail locally:
+- Add file `init_roles.sql` in `klass-shared/initdb/`
+- In the file: `CREATE ROLE "dapla-metadata-developers@groups.ssb.no";`
+
 ### Klass Forvaltning
 
 #### Build

--- a/klass-api/src/main/resources/application-postgres-local.properties
+++ b/klass-api/src/main/resources/application-postgres-local.properties
@@ -15,3 +15,5 @@ spring.flyway.user=klass
 spring.flyway.locations=classpath:db/migration
 # This is for first time running on a database with data, but no flyway schema history table
 spring.flyway.baseline-on-migrate=true
+# Dummy role for local db
+spring.flyway.placeholders.metadata_developer_role=${spring.flyway.user}

--- a/klass-api/src/main/resources/application-postgres-local.properties
+++ b/klass-api/src/main/resources/application-postgres-local.properties
@@ -16,4 +16,4 @@ spring.flyway.locations=classpath:db/migration
 # This is for first time running on a database with data, but no flyway schema history table
 spring.flyway.baseline-on-migrate=true
 # Dummy role for local db
-spring.flyway.placeholders.metadata_developer_role=${spring.flyway.user}
+spring.flyway.placeholders.klass_read_db_developer_group=${spring.flyway.user}

--- a/klass-api/src/main/resources/application.properties
+++ b/klass-api/src/main/resources/application.properties
@@ -73,4 +73,4 @@ spring.jpa.properties.hibernate.default_batch_fetch_size=20
 spring.jpa.properties.hibernate.max_fetch_depth=2
 
 # Placeholder value for DB role (used by Flyway)
-spring.flyway.placeholders.metadata_developer_role="dapla-metadata-developers@groups.ssb.no"
+spring.flyway.placeholders.klass_read_db_developer_group="dapla-metadata-developers@groups.ssb.no"

--- a/klass-api/src/main/resources/application.properties
+++ b/klass-api/src/main/resources/application.properties
@@ -71,3 +71,6 @@ spring.jpa.open-in-view=true
 # Global values for hibernate batch fetching
 spring.jpa.properties.hibernate.default_batch_fetch_size=20
 spring.jpa.properties.hibernate.max_fetch_depth=2
+
+# Placeholder value for DB role (used by Flyway)
+spring.flyway.placeholders.metadata_developer_role="dapla-metadata-developers@groups.ssb.no"

--- a/klass-api/src/main/resources/db/migration/V4__grant_user_role.sql
+++ b/klass-api/src/main/resources/db/migration/V4__grant_user_role.sql
@@ -1,2 +1,0 @@
--- Grant role to user group
-GRANT klass_read TO "dapla-metadata-developers@groups.ssb.no"

--- a/klass-api/src/main/resources/db/migration/V4__grant_user_role.sql
+++ b/klass-api/src/main/resources/db/migration/V4__grant_user_role.sql
@@ -1,0 +1,2 @@
+-- Grant role to user group
+GRANT klass_read TO "dapla-metadata-developers@groups.ssb.no"

--- a/klass-api/src/main/resources/db/migration/V4__grant_user_role.sql
+++ b/klass-api/src/main/resources/db/migration/V4__grant_user_role.sql
@@ -1,2 +1,2 @@
 -- Grant role to user group
-GRANT klass_read TO "dapla-metadata-developers@groups.ssb.no"
+GRANT klass_read TO ${metadata_developer_role}

--- a/klass-api/src/main/resources/db/migration/V4__grant_user_role.sql
+++ b/klass-api/src/main/resources/db/migration/V4__grant_user_role.sql
@@ -1,2 +1,2 @@
 -- Grant role to user group
-GRANT klass_read TO ${metadata_developer_role}
+GRANT klass_read TO "dapla-metadata-developers@groups.ssb.no"

--- a/klass-api/src/main/resources/db/migration/V5__use_configured_group_for_klass_read_grant.sql
+++ b/klass-api/src/main/resources/db/migration/V5__use_configured_group_for_klass_read_grant.sql
@@ -1,0 +1,2 @@
+-- Do not use hardcoded user group
+GRANT klass_read TO ${klass_read_db_developer_group}


### PR DESCRIPTION
- Do not use group email directly in flyway migration 
- Set valid role for local development
- Since V4 already ran in environment test and flyway migrations are immutable the change is added in a new migration
- To solve local problems a work around is described in README