### PR TITLE
Reduce batch size for correspondence tables

### DIFF
--- a/klass-shared/src/main/java/no/ssb/klass/core/model/StatisticalClassification.java
+++ b/klass-shared/src/main/java/no/ssb/klass/core/model/StatisticalClassification.java
@@ -43,7 +43,7 @@ public abstract class StatisticalClassification extends BaseEntity
     private final List<Level> levels;
 
     @OneToMany(mappedBy = "source")
-    @BatchSize(size = 100)
+    @BatchSize(size = 50)
     private final List<CorrespondenceTable> correspondenceTables;
 
     @OneToMany(cascade = CascadeType.ALL)
@@ -51,7 +51,7 @@ public abstract class StatisticalClassification extends BaseEntity
             name = "statisticalclassification_changelog",
             joinColumns = @JoinColumn(name = "statisticalclassification_id"),
             inverseJoinColumns = @JoinColumn(name = "changelog_id"))
-    @BatchSize(size = 100)
+    @BatchSize(size = 50)
     private final List<Changelog> changelogs;
 
     private transient List<ClassificationItem> deletedClassificationItems;


### PR DESCRIPTION
Running mabl Klass performance test environment triggered a series of db errors -  db runs out of temp files space. This is caused by large batch sizes and removal of L2 cache.

Ref:  https://cloudlogging.app.goo.gl/uLGhHZNyhr8i3EHu9

Reduces some very large batch-sizes from 100 to 50 to test if this is enough

Probably will prod environment handle this better, but disc size is equal test and prod. If needed we can look into increasing disc size

