### PR TITLE
Reduce all batch sizes to 20

### DIFF
--- a/klass-shared/src/main/java/no/ssb/klass/core/model/ClassificationSeries.java
+++ b/klass-shared/src/main/java/no/ssb/klass/core/model/ClassificationSeries.java
@@ -88,7 +88,6 @@ public class ClassificationSeries extends BaseEntity implements ClassificationEn
     private final List<ClassificationVersion> classificationVersions = new ArrayList<>();
 
     @ManyToMany
-    @BatchSize(size = 50)
     private final List<StatisticalUnit> statisticalUnits = new ArrayList<>();
 
     @Column(nullable = false)

--- a/klass-shared/src/main/java/no/ssb/klass/core/model/ClassificationSeries.java
+++ b/klass-shared/src/main/java/no/ssb/klass/core/model/ClassificationSeries.java
@@ -16,7 +16,6 @@ import no.ssb.klass.core.util.Translatable;
 import no.ssb.klass.core.util.TranslatablePersistenceConverter;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hibernate.annotations.BatchSize;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -87,8 +86,7 @@ public class ClassificationSeries extends BaseEntity implements ClassificationEn
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "classification")
     private final List<ClassificationVersion> classificationVersions = new ArrayList<>();
 
-    @ManyToMany
-    private final List<StatisticalUnit> statisticalUnits = new ArrayList<>();
+    @ManyToMany private final List<StatisticalUnit> statisticalUnits = new ArrayList<>();
 
     @Column(nullable = false)
     private boolean deleted;

--- a/klass-shared/src/main/java/no/ssb/klass/core/model/StatisticalClassification.java
+++ b/klass-shared/src/main/java/no/ssb/klass/core/model/StatisticalClassification.java
@@ -43,7 +43,6 @@ public abstract class StatisticalClassification extends BaseEntity
     private final List<Level> levels;
 
     @OneToMany(mappedBy = "source")
-    @BatchSize(size = 50)
     private final List<CorrespondenceTable> correspondenceTables;
 
     @OneToMany(cascade = CascadeType.ALL)
@@ -51,7 +50,6 @@ public abstract class StatisticalClassification extends BaseEntity
             name = "statisticalclassification_changelog",
             joinColumns = @JoinColumn(name = "statisticalclassification_id"),
             inverseJoinColumns = @JoinColumn(name = "changelog_id"))
-    @BatchSize(size = 50)
     private final List<Changelog> changelogs;
 
     private transient List<ClassificationItem> deletedClassificationItems;

--- a/klass-shared/src/main/java/no/ssb/klass/core/model/StatisticalClassification.java
+++ b/klass-shared/src/main/java/no/ssb/klass/core/model/StatisticalClassification.java
@@ -14,8 +14,6 @@ import no.ssb.klass.core.util.TimeUtil;
 import no.ssb.klass.core.util.Translatable;
 import no.ssb.klass.core.util.TranslatablePersistenceConverter;
 
-import org.hibernate.annotations.BatchSize;
-
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;


### PR DESCRIPTION
In the process of testing how we kan keep responses from Klass stable.
Large Batch sizes results in db disk errors. 