### PR TITLE
Update tomcat version to secure version 10.1.55

### DIFF
--- a/klass-api/pom.xml
+++ b/klass-api/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <snippetsDirectory>${project.build.directory}/generated-snippets</snippetsDirectory>
+        <tomcat.version>10.1.55</tomcat.version>
     </properties>
 
 

--- a/klass-index-job/pom.xml
+++ b/klass-index-job/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <tomcat.version>10.1.55</tomcat.version>
     </properties>
 
 

--- a/klass-mail/pom.xml
+++ b/klass-mail/pom.xml
@@ -15,6 +15,7 @@
 
     <properties>
         <spring-cloud-gcp-dependencies.version>7.4.6</spring-cloud-gcp-dependencies.version>
+        <tomcat.version>10.1.55</tomcat.version>
     </properties>
 
     <dependencies>

--- a/klass-shared/pom.xml
+++ b/klass-shared/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <tomcat.version>10.1.55</tomcat.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Transitive dependency from `org.springframework.boot:spring-boot-starter-tomcat:jar:3.5.13` 

Available fixed version provided by overriding version from spring boot

Scan before Klass api
<img width="896" height="303" alt="Skjermbilde 2026-05-19 kl  20 24 14" src="https://github.com/user-attachments/assets/c841103a-3597-4f12-8c53-cdd90b349fe9" />

Scan after:
<img width="1066" height="180" alt="Skjermbilde 2026-05-19 kl  20 47 55" src="https://github.com/user-attachments/assets/171754b4-5e65-4965-823a-332fd3cb9ac7" />

Fixed:
- klass-api
- klass-shared
- klass-mail
- klass-index-job