### PR TITLE
Don't expose contact phone numbers in the API

### DIFF
--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ContactPersonResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ContactPersonResource.java
@@ -10,7 +10,7 @@ public class ContactPersonResource {
     public ContactPersonResource(User contactPerson) {
         name = contactPerson.getFullname();
         email = contactPerson.getEmail();
-        phone = contactPerson.getPhone();
+        phone = "";  // We no longer expose phone numbers ref DPMETA-1469
     }
 
     public String getName() {

--- a/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ContactPersonResource.java
+++ b/klass-api/src/main/java/no/ssb/klass/api/dto/hal/ContactPersonResource.java
@@ -10,7 +10,7 @@ public class ContactPersonResource {
     public ContactPersonResource(User contactPerson) {
         name = contactPerson.getFullname();
         email = contactPerson.getEmail();
-        phone = "";  // We no longer expose phone numbers ref DPMETA-1469
+        phone = ""; // We no longer expose phone numbers ref DPMETA-1469
     }
 
     public String getName() {

--- a/klass-api/src/test/java/no/ssb/klass/api/applicationtest/RestApiCorrespondenceTablesIntegrationTest.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/applicationtest/RestApiCorrespondenceTablesIntegrationTest.java
@@ -23,6 +23,7 @@ public class RestApiCorrespondenceTablesIntegrationTest extends AbstractRestApiA
                 .statusCode(HttpStatus.OK.value())
                 .body("name", is("Kommuneinndeling 2014 - Bydelsinndeling 2014"))
                 .body("contactPerson", notNullValue())
+                .body("contactPerson.phone", is(""))
                 .body("owningSection", is("section"))
                 .body("source", is("Kommuneinndeling 2014"))
                 .body("sourceId", is(correspondenceTable.getSource().getId().intValue()))

--- a/klass-api/src/test/java/no/ssb/klass/api/applicationtest/RestApiVersionsIntegrationTest.java
+++ b/klass-api/src/test/java/no/ssb/klass/api/applicationtest/RestApiVersionsIntegrationTest.java
@@ -21,6 +21,7 @@ public class RestApiVersionsIntegrationTest extends AbstractRestApiApplicationTe
                 .statusCode(HttpStatus.OK.value())
                 .body("name", is("Badminton 2006"))
                 .body("contactPerson.name", is("Ziggy Stardust"))
+                .body("contactPerson.phone", is(""))
                 .body("owningSection", is("section"))
                 .body("classificationVariants[0].owningSection", is("425"))
                 .body("classificationVariants[1].owningSection", is("150"));


### PR DESCRIPTION
The field is retained to avoid breaking consumers.