### PR TITLE
Add monthly Docker Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,3 +59,33 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+  - package-ecosystem: docker
+    directory: "/klass-api"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+  - package-ecosystem: docker
+    directory: "/klass-forvaltning"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+  - package-ecosystem: docker
+    directory: "/klass-index-job"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+  - package-ecosystem: docker
+    directory: "/klass-mail"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+  - package-ecosystem: docker
+    directory: "/klass-solr"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## What
- add Dependabot docker ecosystem updates for directories containing Dockerfiles
- run monthly schedule
- set cooldown default-days to 7

## Why
Keep Docker base image dependencies updated on a regular cadence with a cooldown period.