### PR TITLE
Fix transaction failures caused by subscriber notification errors

### DIFF
--- a/klass-forvaltning/src/main/java/no/ssb/klass/designer/editing/variant/EditVariantEditorView.java
+++ b/klass-forvaltning/src/main/java/no/ssb/klass/designer/editing/variant/EditVariantEditorView.java
@@ -97,10 +97,21 @@ public class EditVariantEditorView extends EditVariantEditorDesign implements Ed
         header.setTypeText(TypeAndNameHeaderComponent.TEXT_VARIANT_OF + variant.getClassificationVersion()
                 .getNameInPrimaryLanguage());
         header.setNameText(variant.getNameInPrimaryLanguage());
-        checkUserAccess();
-        // NB. checkUserAccess() must be before codeEditor.init(..), if not a NewCodeEditor will be
-        // added even when user does not have permission to alter variant.
+        boolean canAlter = userContext.canUserAlterObject(variant);
+        log.info("canUserAlterObject({}) = {}", variant.getId(), canAlter);
+        // NB. codeEditor.setReadOnly() must be called AFTER codeEditor.init(), because
+        // configureDragDrop() selects a default value in the OptionGroup and would throw
+        // ReadOnlyException if the component is already read-only at that point.
+        if (!canAlter) {
+            actionButtons.disableConfirmButton(true, "Du har ikke lov til å endre denne varianten");
+            metadataEditor.setReadOnly(true);
+        } else {
+            actionButtons.disableConfirmButton(false, "");
+        }
         codeEditor.init(variant, classificationFacade, applicationContext, xmlService);
+        if (!canAlter) {
+            codeEditor.setReadOnly(true);
+        }
         if (editingState.isCodeEditorNotMetadataVisible()) {
             accordion.setSelectedTab(codeEditor);
             codeEditor.restorePreviousEditingState(editingState);
@@ -124,15 +135,6 @@ public class EditVariantEditorView extends EditVariantEditorDesign implements Ed
         ignoreChanges = true;
     }
 
-    private void checkUserAccess() {
-        if (!userContext.canUserAlterObject(variant)) {
-            actionButtons.disableConfirmButton(true, "Du har ikke lov til å endre denne varianten");
-            metadataEditor.setReadOnly(true);
-            codeEditor.setReadOnly(true);
-        } else {
-            actionButtons.disableConfirmButton(false, "");
-        }
-    }
 
     private void saveClick(Button.ClickEvent clickEvent) {
         codeEditor.prepareSave();

--- a/klass-forvaltning/src/main/java/no/ssb/klass/designer/service/ClassificationFacade.java
+++ b/klass-forvaltning/src/main/java/no/ssb/klass/designer/service/ClassificationFacade.java
@@ -206,19 +206,24 @@ public class ClassificationFacade {
     }
 
     /**
-     * Notifies subscribers about an updated classification. Errors are caught and logged rather
-     * than propagated, so a transient notification failure never rolls back an already-committed
-     * save/delete operation.
+     * Notifies subscribers about an updated classification asynchronously so that a slow or
+     * unreachable mail service never blocks the HTTP request / UI save operation. Errors are
+     * logged but never propagated, since the data has already been committed successfully.
      */
     private void tryInformSubscribers(ClassificationSeries classification, String whatChanged,
             String descriptionOfChange) {
-        try {
-            subscriberService.informSubscribersOfUpdatedClassification(classification, whatChanged,
-                    descriptionOfChange);
-        } catch (Exception e) {
-            log.error("Failed to notify subscribers for classification {}: {}",
-                    classification.getId(), e.getMessage(), e);
-        }
+        Thread thread = new Thread(() -> {
+            try {
+                subscriberService.informSubscribersOfUpdatedClassification(classification, whatChanged,
+                        descriptionOfChange);
+            } catch (Exception e) {
+                log.error("Failed to notify subscribers for classification {}: {}",
+                        classification.getId(), e.getMessage(), e);
+            }
+        });
+        thread.setName("subscriber-notification-" + classification.getId());
+        thread.setDaemon(true);
+        thread.start();
     }
 
     public void deleteStatisticalUnit(StatisticalUnit statisticalUnit) {

--- a/klass-forvaltning/src/main/java/no/ssb/klass/designer/service/ClassificationFacade.java
+++ b/klass-forvaltning/src/main/java/no/ssb/klass/designer/service/ClassificationFacade.java
@@ -6,6 +6,8 @@ import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import no.ssb.klass.core.model.Changelog;
 import no.ssb.klass.core.model.ClassificationFamily;
@@ -109,6 +111,7 @@ public class ClassificationFacade {
         return classificationService.saveStatisticalUnit(stat);
     }
 
+    @Transactional(propagation = Propagation.NEVER)
     public ClassificationSeries saveClassification(ClassificationSeries classification) {
         classificationService.saveNotIndexClassification(classification);
         log.info("Classification saved {}", classification);
@@ -118,6 +121,7 @@ public class ClassificationFacade {
         return classification;
     }
 
+    @Transactional(propagation = Propagation.NEVER)
     public CorrespondenceTable saveCorrespondenceTable(CorrespondenceTable correspondenceTable,
                                                        InformSubscribers informSubscribers) {
         classificationService.saveNotIndexCorrespondenceTable(correspondenceTable);
@@ -130,6 +134,7 @@ public class ClassificationFacade {
         return correspondenceTable;
     }
 
+    @Transactional(propagation = Propagation.NEVER)
     public void saveVariant(ClassificationVariant variant,
                                              InformSubscribers informSubscribers) {
         classificationService.saveNotIndexVariant(variant);
@@ -141,6 +146,7 @@ public class ClassificationFacade {
         }
     }
 
+    @Transactional(propagation = Propagation.NEVER)
     public ClassificationVersion saveVersion(ClassificationVersion version,
                                              InformSubscribers informSubscribers) {
         classificationService.saveNotIndexVersion(version);
@@ -157,6 +163,7 @@ public class ClassificationFacade {
         return classificationService.copyClassificationVersion(originalVersion, dateRange);
     }
 
+    @Transactional(propagation = Propagation.NEVER)
     public void deleteClassification(User currentUser, ClassificationSeries classification)
             throws KlassMessageException {
         classificationService.deleteNotIndexClassification(currentUser, classification);
@@ -165,6 +172,7 @@ public class ClassificationFacade {
                 + classification.getNameInPrimaryLanguage(), "Klassifikasjonen er slettet");
     }
 
+    @Transactional(propagation = Propagation.NEVER)
     public void deleteCorrespondenceTable(User currentUser,
             CorrespondenceTable correspondenceTable) throws KlassMessageException {
         classificationService.deleteNotIndexCorrespondenceTable(currentUser, correspondenceTable);
@@ -176,6 +184,7 @@ public class ClassificationFacade {
         }
     }
 
+    @Transactional(propagation = Propagation.NEVER)
     public void deleteVariant(User currentUser, ClassificationVariant variant)
             throws KlassMessageException {
         classificationService.deleteNotIndexVariant(currentUser, variant);
@@ -186,6 +195,7 @@ public class ClassificationFacade {
         }
     }
 
+    @Transactional(propagation = Propagation.NEVER)
     public void deleteVersion(User currentUser, ClassificationVersion version) throws KlassMessageException {
         classificationService.deleteNotIndexVersion(currentUser, version);
         log.info("Version {} deleted", version);

--- a/klass-forvaltning/src/main/java/no/ssb/klass/designer/service/ClassificationFacade.java
+++ b/klass-forvaltning/src/main/java/no/ssb/klass/designer/service/ClassificationFacade.java
@@ -115,7 +115,7 @@ public class ClassificationFacade {
     public ClassificationSeries saveClassification(ClassificationSeries classification) {
         classificationService.saveNotIndexClassification(classification);
         log.info("Classification saved {}", classification);
-        subscriberService.informSubscribersOfUpdatedClassification(classification,
+        tryInformSubscribers(classification,
                 "Endring i metadata for klassifikasjonen: " + classification.getNameInPrimaryLanguage(),
                 "Oppdatert metadata for klassifikasjonen");
         return classification;
@@ -127,7 +127,7 @@ public class ClassificationFacade {
         classificationService.saveNotIndexCorrespondenceTable(correspondenceTable);
         log.info("Correspondence table saved {}", correspondenceTable);
         if (informSubscribers.isInformSubscribers()) {
-            subscriberService.informSubscribersOfUpdatedClassification(correspondenceTable.getOwnerClassification(),
+            tryInformSubscribers(correspondenceTable.getOwnerClassification(),
                     "Endring i korrespondansetabellen: " + correspondenceTable.getNameInPrimaryLanguage(),
                     informSubscribers.getDescriptionOfChange());
         }
@@ -140,9 +140,9 @@ public class ClassificationFacade {
         classificationService.saveNotIndexVariant(variant);
         log.info("Classification variant saved {}", variant);
         if (informSubscribers.isInformSubscribers()) {
-            subscriberService.informSubscribersOfUpdatedClassification(variant.getOwnerClassification(),
-                    "Endring i varianten: " + variant.getNameInPrimaryLanguage(), informSubscribers
-                            .getDescriptionOfChange());
+            tryInformSubscribers(variant.getOwnerClassification(),
+                    "Endring i varianten: " + variant.getNameInPrimaryLanguage(),
+                    informSubscribers.getDescriptionOfChange());
         }
     }
 
@@ -152,9 +152,9 @@ public class ClassificationFacade {
         classificationService.saveNotIndexVersion(version);
         log.info("Classification version saved {}", version);
         if (informSubscribers.isInformSubscribers()) {
-            subscriberService.informSubscribersOfUpdatedClassification(version.getOwnerClassification(),
-                    "Endring i versjonen: " + version.getNameInPrimaryLanguage(), informSubscribers
-                            .getDescriptionOfChange());
+            tryInformSubscribers(version.getOwnerClassification(),
+                    "Endring i versjonen: " + version.getNameInPrimaryLanguage(),
+                    informSubscribers.getDescriptionOfChange());
         }
         return version;
     }
@@ -168,7 +168,7 @@ public class ClassificationFacade {
             throws KlassMessageException {
         classificationService.deleteNotIndexClassification(currentUser, classification);
         log.info("Classification {} deleted", classification);
-        subscriberService.informSubscribersOfUpdatedClassification(classification, "Klassifikasjonen er slettet: "
+        tryInformSubscribers(classification, "Klassifikasjonen er slettet: "
                 + classification.getNameInPrimaryLanguage(), "Klassifikasjonen er slettet");
     }
 
@@ -178,7 +178,7 @@ public class ClassificationFacade {
         classificationService.deleteNotIndexCorrespondenceTable(currentUser, correspondenceTable);
         log.info("Correspondence table {} deleted", correspondenceTable);
         if (correspondenceTable.isPublishedInAnyLanguage()) {
-            subscriberService.informSubscribersOfUpdatedClassification(correspondenceTable.getOwnerClassification(),
+            tryInformSubscribers(correspondenceTable.getOwnerClassification(),
                     "Korrespondansetabellen er slettet: " + correspondenceTable.getNameInPrimaryLanguage(),
                     "En korrespondansetabell er slettet");
         }
@@ -190,7 +190,7 @@ public class ClassificationFacade {
         classificationService.deleteNotIndexVariant(currentUser, variant);
         log.info("Variant {} deleted", variant);
         if (variant.isPublishedInAnyLanguage()) {
-            subscriberService.informSubscribersOfUpdatedClassification(variant.getOwnerClassification(),
+            tryInformSubscribers(variant.getOwnerClassification(),
                     "Varianten er slettet: " + variant.getNameInPrimaryLanguage(), "En variant er slettet");
         }
     }
@@ -200,8 +200,24 @@ public class ClassificationFacade {
         classificationService.deleteNotIndexVersion(currentUser, version);
         log.info("Version {} deleted", version);
         if (version.isPublishedInAnyLanguage()) {
-            subscriberService.informSubscribersOfUpdatedClassification(version.getOwnerClassification(),
+            tryInformSubscribers(version.getOwnerClassification(),
                     "Versjonen er slettet: " + version.getNameInPrimaryLanguage(), "En versjon er slettet");
+        }
+    }
+
+    /**
+     * Notifies subscribers about an updated classification. Errors are caught and logged rather
+     * than propagated, so a transient notification failure never rolls back an already-committed
+     * save/delete operation.
+     */
+    private void tryInformSubscribers(ClassificationSeries classification, String whatChanged,
+            String descriptionOfChange) {
+        try {
+            subscriberService.informSubscribersOfUpdatedClassification(classification, whatChanged,
+                    descriptionOfChange);
+        } catch (Exception e) {
+            log.error("Failed to notify subscribers for classification {}: {}",
+                    classification.getId(), e.getMessage(), e);
         }
     }
 

--- a/klass-forvaltning/src/main/resources/application-postgres.properties
+++ b/klass-forvaltning/src/main/resources/application-postgres.properties
@@ -4,9 +4,11 @@ spring.datasource.url=${NAIS_DATABASE_KLASS_KLASS_JDBC_URL}
 spring.datasource.tomcat.max-active=5
 spring.datasource.tomcat.max-idle=5
 spring.datasource.tomcat.remove-abandoned=true
+# Validate connections before borrowing to avoid stale/closed connections from Cloud SQL
+spring.datasource.tomcat.test-on-borrow=true
+spring.datasource.tomcat.validation-query=SELECT 1
+spring.datasource.tomcat.validation-query-timeout=3
 flyway.enabled=false
 spring.jpa.hibernate.ddl-auto=none
-spring.datasource.hikari.connection-test-query=SELECT 1
-spring.datasource.hikari.validation-timeout=3000
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect

--- a/klass-forvaltning/src/main/resources/application.properties
+++ b/klass-forvaltning/src/main/resources/application.properties
@@ -42,7 +42,7 @@ klass.env.search.solr.core=Klass
 
 # Security properties
 # Only for test/development user. Valid values are STANDARD, ADMIN.
-klass.security.hardcoded.user.role=ADMIN
+klass.security.hardcoded.user.role=STANDARD
 klass.security.roles.admin.users=
 klass.security.oauth2.jwt.jwks.uri=https://auth.test.ssb.no/realms/ssb/protocol/openid-connect/certs
 klass.security.oauth2.jwt.issuer=https://auth.test.ssb.no/realms/ssb

--- a/klass-forvaltning/src/main/resources/application.properties
+++ b/klass-forvaltning/src/main/resources/application.properties
@@ -42,7 +42,7 @@ klass.env.search.solr.core=Klass
 
 # Security properties
 # Only for test/development user. Valid values are STANDARD, ADMIN.
-klass.security.hardcoded.user.role=STANDARD
+klass.security.hardcoded.user.role=ADMIN
 klass.security.roles.admin.users=
 klass.security.oauth2.jwt.jwks.uri=https://auth.test.ssb.no/realms/ssb/protocol/openid-connect/certs
 klass.security.oauth2.jwt.issuer=https://auth.test.ssb.no/realms/ssb

--- a/klass-forvaltning/src/test/java/no/ssb/klass/ClassificationFacadeTest.java
+++ b/klass-forvaltning/src/test/java/no/ssb/klass/ClassificationFacadeTest.java
@@ -239,6 +239,6 @@ public class ClassificationFacadeTest {
     }
 
     private void verifyInformSubscribers() {
-        verify(subscriberServiceMock).informSubscribersOfUpdatedClassification(any(), any(), any());
+        verify(subscriberServiceMock, timeout(2000)).informSubscribersOfUpdatedClassification(any(), any(), any());
     }
 }


### PR DESCRIPTION
This PR fixes an issue where failures in subscriber notifications could prevent classification save/delete operations from completing successfully.

Previously, `@Transactional(propagation = Propagation.NEVER)` was removed during indexing changes. But it was not the only transaction making problems.  Slow or failing mail services could cause the entire transaction to fail and roll back.

This PR also fixes check for user access triggered at the wrong time causing exception when opening a variant if not write access.

## Changes

* Reintroduced transaction isolation to prevent subscriber notification failures from affecting persistence operations.
* Added a `tryInformSubscribers(...)` helper method that executes subscriber notifications asynchronously in a separate daemon thread.
* Added exception handling around subscriber notifications so that any mail service failures are logged but never propagated back to the caller.
*  Call codeEditor.setReadOnly()  AFTER codeEditor.init() to avoid ReadOnlyException 

## Result

* Save/delete operations now complete successfully even if the mail service is slow or unavailable.
* Subscriber notification failures are logged for troubleshooting but do not impact persisted data.

Dev: https://klass-dev.intern.test.ssb.no/klass/admin/klassui#!

This variant was reported from user failing to open and edit:
https://klass-dev.intern.test.ssb.no/klass/admin/klassui#!variantEditor/?variantId=3169

