### PR TITLE
Invalidate second level cache

### DIFF
--- a/klass-api/src/main/resources/application-postgres-embedded.properties
+++ b/klass-api/src/main/resources/application-postgres-embedded.properties
@@ -2,3 +2,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=create-drop
 # Flyway
 spring.flyway.enabled=false
+# Disable second-level cache in tests: schema is recreated per run (create-drop),
+# caching adds no value and requires a running JCache provider.
+spring.jpa.properties.hibernate.cache.use_second_level_cache=false
+spring.jpa.properties.hibernate.cache.region.factory_class=org.hibernate.cache.internal.NoCachingRegionFactory

--- a/klass-api/src/main/resources/application.properties
+++ b/klass-api/src/main/resources/application.properties
@@ -77,10 +77,10 @@ spring.flyway.placeholders.klass_read_db_developer_group="dapla-metadata-develop
 
 # Collect Hibernate statistics
 spring.jpa.properties.hibernate.generate_statistics=true
+# Comment out logs in production – can be noisy.
 # Session-level stats: logs "second level cache hits/misses/puts: N" at end of every session.
 # logging.level.org.hibernate.stat=DEBUG
 # SQL logging: a SELECT appearing here means a cache miss (Hibernate went to DB).
-# Comment out in production – can be noisy.
 # logging.level.org.hibernate.SQL=DEBUG
 
 # Enable Hibernate second-level cache via JCache / Ehcache 3
@@ -92,9 +92,6 @@ spring.jpa.properties.hibernate.cache.region.factory_class=org.hibernate.cache.j
 spring.jpa.properties.hibernate.javax.cache.provider=org.ehcache.jsr107.EhcacheCachingProvider
 # Use classpath: URI – Hibernate 6's JCacheRegionFactory checks for scheme "classpath" and
 # calls ClassLoader.getResource(getSchemeSpecificPart()) to resolve it.
-# NOTE: do NOT use classpath:// (double slash) – that makes the URI hierarchical, turning
-# "ehcache.xml" into the *host* component so getSchemeSpecificPart() returns "//ehcache.xml"
-# and the resource lookup fails.
 spring.jpa.properties.hibernate.javax.cache.uri=classpath:ehcache.xml
 # Warn (not silently create eternal caches) when a region is missing from ehcache.xml
 spring.jpa.properties.hibernate.javax.cache.missing_cache_strategy=create-warn

--- a/klass-api/src/main/resources/application.properties
+++ b/klass-api/src/main/resources/application.properties
@@ -81,7 +81,7 @@ spring.jpa.properties.hibernate.generate_statistics=true
 logging.level.org.hibernate.stat=DEBUG
 # SQL logging: a SELECT appearing here means a cache miss (Hibernate went to DB).
 # Comment out in production – can be noisy.
-logging.level.org.hibernate.SQL=DEBUG
+# logging.level.org.hibernate.SQL=DEBUG
 
 # Enable Hibernate second-level cache via JCache / Ehcache 3
 # NOTE: these settings must live here (klass-api) because Spring Boot 3.x loads only the

--- a/klass-api/src/main/resources/application.properties
+++ b/klass-api/src/main/resources/application.properties
@@ -35,7 +35,7 @@ klass.env.api.base=${klass.env.api.base.path}${klass.env.api.base.version}
 server.tomcat.remoteip.host-header=X-SSB-Forwarded-Host
 management.server.port=8080
 management.endpoints.web.base-path=/actuator
-management.endpoints.web.exposure.include=health,prometheus
+management.endpoints.web.exposure.include=health,prometheus,caches
 management.endpoint.prometheus.access=unrestricted
 management.endpoint.health.show-details=always
 management.endpoint.health.show-components=always
@@ -77,5 +77,25 @@ spring.flyway.placeholders.klass_read_db_developer_group="dapla-metadata-develop
 
 # Collect Hibernate statistics
 spring.jpa.properties.hibernate.generate_statistics=true
-# logging.level.org.hibernate.stat=DEBUG
+# Session-level stats: logs "second level cache hits/misses/puts: N" at end of every session.
+logging.level.org.hibernate.stat=DEBUG
+# SQL logging: a SELECT appearing here means a cache miss (Hibernate went to DB).
+# Comment out in production – can be noisy.
+logging.level.org.hibernate.SQL=DEBUG
+
+# Enable Hibernate second-level cache via JCache / Ehcache 3
+# NOTE: these settings must live here (klass-api) because Spring Boot 3.x loads only the
+# first application.properties found on the classpath; klass-shared's copy is not picked up.
+spring.jpa.properties.hibernate.cache.use_second_level_cache=true
+spring.jpa.properties.hibernate.cache.generate_statistics=true
+spring.jpa.properties.hibernate.cache.region.factory_class=org.hibernate.cache.jcache.internal.JCacheRegionFactory
+spring.jpa.properties.hibernate.javax.cache.provider=org.ehcache.jsr107.EhcacheCachingProvider
+# Use classpath: URI – Hibernate 6's JCacheRegionFactory checks for scheme "classpath" and
+# calls ClassLoader.getResource(getSchemeSpecificPart()) to resolve it.
+# NOTE: do NOT use classpath:// (double slash) – that makes the URI hierarchical, turning
+# "ehcache.xml" into the *host* component so getSchemeSpecificPart() returns "//ehcache.xml"
+# and the resource lookup fails.
+spring.jpa.properties.hibernate.javax.cache.uri=classpath:ehcache.xml
+# Warn (not silently create eternal caches) when a region is missing from ehcache.xml
+spring.jpa.properties.hibernate.javax.cache.missing_cache_strategy=create-warn
 

--- a/klass-api/src/main/resources/application.properties
+++ b/klass-api/src/main/resources/application.properties
@@ -78,7 +78,7 @@ spring.flyway.placeholders.klass_read_db_developer_group="dapla-metadata-develop
 # Collect Hibernate statistics
 spring.jpa.properties.hibernate.generate_statistics=true
 # Session-level stats: logs "second level cache hits/misses/puts: N" at end of every session.
-logging.level.org.hibernate.stat=DEBUG
+# logging.level.org.hibernate.stat=DEBUG
 # SQL logging: a SELECT appearing here means a cache miss (Hibernate went to DB).
 # Comment out in production – can be noisy.
 # logging.level.org.hibernate.SQL=DEBUG

--- a/klass-api/src/main/resources/application.properties
+++ b/klass-api/src/main/resources/application.properties
@@ -80,8 +80,6 @@ spring.jpa.properties.hibernate.generate_statistics=true
 # Comment out logs in production – can be noisy.
 # Session-level stats: logs "second level cache hits/misses/puts: N" at end of every session.
 # logging.level.org.hibernate.stat=DEBUG
-# SQL logging: a SELECT appearing here means a cache miss (Hibernate went to DB).
-# logging.level.org.hibernate.SQL=DEBUG
 
 # Enable Hibernate second-level cache via JCache / Ehcache 3
 # NOTE: these settings must live here (klass-api) because Spring Boot 3.x loads only the

--- a/klass-shared/src/main/resources/application.properties
+++ b/klass-shared/src/main/resources/application.properties
@@ -6,5 +6,7 @@ spring.jpa.properties.hibernate.cache.use_second_level_cache=true
 spring.jpa.properties.hibernate.cache.generate_statistics=true
 spring.jpa.properties.hibernate.cache.region.factory_class=org.hibernate.cache.jcache.internal.JCacheRegionFactory
 spring.jpa.properties.hibernate.javax.cache.provider=org.ehcache.jsr107.EhcacheCachingProvider
-spring.jpa.properties.hibernate.javax.cache.missing_cache_strategy=create
+spring.jpa.properties.hibernate.javax.cache.missing_cache_strategy=create-warn
+# Use classpath: URI – Hibernate 6's JCacheRegionFactory checks for scheme "classpath" and
+# calls ClassLoader.getResource(getSchemeSpecificPart()) to resolve it.
 spring.jpa.properties.hibernate.javax.cache.uri=classpath:ehcache.xml

--- a/klass-shared/src/main/resources/ehcache.xml
+++ b/klass-shared/src/main/resources/ehcache.xml
@@ -2,31 +2,30 @@
         xmlns="http://www.ehcache.org/v3"
         xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd">
 
-    <cache alias="default">
+    <!--
+      Default template used by all named caches below.
+      Also used as a baseline for any cache regions created at runtime via
+      hibernate.javax.cache.missing_cache_strategy=create-warn.
+      NOTE: Ehcache 3 does NOT automatically apply this template to JCache-API-created
+      caches; see named caches below for the regions Hibernate actually uses.
+    -->
+    <cache-template name="default-ttl">
         <expiry>
-            <ttl unit="minutes">20</ttl>
+            <ttl unit="minutes">20  </ttl>
         </expiry>
         <resources>
             <heap>10000</heap>
             <offheap unit="MB">100</offheap>
         </resources>
-    </cache>
-    <cache alias="no.ssb.klass.core.model.CorrespondenceMap">
-        <expiry>
-            <ttl unit="minutes">20</ttl>
-        </expiry>
-        <resources>
-            <heap>10000</heap>
-            <offheap unit="MB">100</offheap>
-        </resources>
-    </cache>
-    <cache alias="no.ssb.klass.core.model.CorrespondenceTable.correspondenceMaps">
-        <expiry>
-            <ttl unit="minutes">20</ttl>
-        </expiry>
-        <resources>
-            <heap>10000</heap>
-            <offheap unit="MB">100</offheap>
-        </resources>
-    </cache>
+    </cache-template>
+
+    <!-- Fallback region (named "default") – not used by Hibernate directly -->
+    <cache alias="default" uses-template="default-ttl"/>
+
+    <!-- Hibernate second-level cache: CorrespondenceMap entity -->
+    <cache alias="no.ssb.klass.core.model.CorrespondenceMap" uses-template="default-ttl"/>
+
+    <!-- Hibernate second-level cache: CorrespondenceTable.correspondenceMaps collection -->
+    <cache alias="no.ssb.klass.core.model.CorrespondenceTable.correspondenceMaps" uses-template="default-ttl"/>
+
 </config>


### PR DESCRIPTION
Ref: https://statistics-norway.atlassian.net/browse/DPMETA-1446

There has been an issue where second level cache was never invalidated. This was mainly caused by starting cache provider in `klass-shared`, but properties not picked up by `klass-api` runtime and therefore the cache was never invalidated. 

This PR makes sure all properties and classpath to `ehcache.xml` is also in `klass-api/application.properties`.
Also fix other errors in the set up.

The `ttl` is set to 20 minutes now, this can be adjusted when we see how it works.

This is a request where there is hits in cache (82 L2C hits)
<img width="793" height="187" alt="klippet" src="https://github.com/user-attachments/assets/c6666159-004d-4833-a366-0f35cd5188bf" />

20 minutes later there is no hits, but instead 82 L2c puts
<img width="815" height="204" alt="Skjermbilde 2026-06-30 kl  11 11 44" src="https://github.com/user-attachments/assets/545d8cb0-9da7-4f11-8af6-dc80e4202534" />




