### PR TITLE
fix(security): bump jackson-bom to 2.21.4 for CVE-2026-54513

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
         <commons-io-version>2.22.0</commons-io-version>
         <commons-lang3-version>3.20.0</commons-lang3-version>
         <guava-version>33.6.0-jre</guava-version>
-        <jackson-bom.version>2.21.2</jackson-bom.version>
+        <!-- CVE-2026-54513 (HIGH, CVSS 8.1): fixed in 2.21.3+ -->
+        <jackson-bom.version>2.21.4</jackson-bom.version>
         <jakarta-rs-api-version>4.0.0</jakarta-rs-api-version>
         <jaxb-api-version>4.0.5</jaxb-api-version>
         <maven-jaxb2-plugin-version>2.5.0</maven-jaxb2-plugin-version>


### PR DESCRIPTION
Bumps `jackson-bom.version` from 2.21.2 to 2.21.4 to fix CVE-2026-54513 (HIGH, CVSS 8.1) in `com.fasterxml.jackson.core:jackson-databind`.

Affects klass-mail and klass-index-job. Verified: `dependency:tree` resolves 2.21.4 for both modules, `mvn verify` and `fmt:check` pass.