### PR TITLE
fix(security): bump jackson-databind to 3.2.0 in klass-mail for CVE in 3.0.1

### DIFF
--- a/klass-mail/pom.xml
+++ b/klass-mail/pom.xml
@@ -45,6 +45,18 @@
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
             <version>9.0</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>jackson-databind</artifactId>
+                    <groupId>tools.jackson.core</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <!-- Needed to override the version for logstash-logback-encoder to one with vulnerability fixes -->
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>3.2.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Summary

Fixes `pkg:maven/tools.jackson.core/jackson-databind@3.0.1` vulnerability in `klass-mail`.

`logstash-logback-encoder:9.0` transitively pulls in `jackson-databind:3.0.1` which has a known CVE. This applies the same fix already used in `klass-api` and `klass-index-job`:

1. Exclude `tools.jackson.core:jackson-databind` from `logstash-logback-encoder`
2. Add explicit dependency on `jackson-databind:3.2.0`