### PR TITLE
Handle duplicate codes in Klass Forvaltning

### DIFF
--- a/klass-forvaltning/src/main/java/no/ssb/klass/designer/editing/codetables/PrimaryCodeTable.java
+++ b/klass-forvaltning/src/main/java/no/ssb/klass/designer/editing/codetables/PrimaryCodeTable.java
@@ -69,6 +69,13 @@ public class PrimaryCodeTable extends EditableCodeTable {
     @Override
     protected Item addClassificationItemToTable(ClassificationItem classificationItem) {
         Item item = super.addClassificationItemToTable(classificationItem);
+        if (item == null) {
+            log.warn(
+                    "Could not add ClassificationItem to table (uuid={} already exists in container or is null);"
+                            + " skipping delete-button setup for code={}",
+                    classificationItem.getUuid(), classificationItem.getCode());
+            return null;
+        }
         Button deleteButton = new Button(FontAwesome.TRASH_O);
         deleteButton.addStyleName(ValoTheme.BUTTON_BORDERLESS);
         deleteButton.setHeight("100%");

--- a/klass-forvaltning/src/main/java/no/ssb/klass/designer/editing/codetables/PrimaryCodeTable.java
+++ b/klass-forvaltning/src/main/java/no/ssb/klass/designer/editing/codetables/PrimaryCodeTable.java
@@ -70,7 +70,7 @@ public class PrimaryCodeTable extends EditableCodeTable {
     protected Item addClassificationItemToTable(ClassificationItem classificationItem) {
         Item item = super.addClassificationItemToTable(classificationItem);
         if (item == null) {
-            log.warn(
+            log.info(
                     "Could not add ClassificationItem to table (uuid={} already exists in container or is null);"
                             + " skipping delete-button setup for code={}",
                     classificationItem.getUuid(), classificationItem.getCode());


### PR DESCRIPTION
There is, unknown why, some duplicate codes in for example variant 3533. 
They have also duplicate uuids (which is used for 'equals' and therefore are the duplicates in some ways filtered as null in parent class). 
This causes the code section to crash (triggers `nullpointer exception`) when edit section tries to add 'null' item with delete button. Edit codes will not build and it is not possible to edit the variant.

The best would be to display duplicates and let user delete. 
But this must be done in backport branch probably, adding it to list just triggers cascading errors with hibernate update etc. 

Adding log info so it is easier to detect when there are duplicates.

For now this PR handles duplicates by returning a controlled null without exception